### PR TITLE
[BE] [feat] 관리자 로그인

### DIFF
--- a/be/promotion/src/docs/asciidoc/admin.adoc
+++ b/be/promotion/src/docs/asciidoc/admin.adoc
@@ -13,3 +13,18 @@ include::{snippets}/admin/auth/signup/http-response.adoc[]
 ==== Request Fields
 
 include::{snippets}/admin/auth/signup/request-fields.adoc[]
+
+=== 로그인
+
+.HTTP REQUEST
+include::{snippets}/admin/auth/signin/http-request.adoc[]
+.HTTP RESPONSE
+include::{snippets}/admin/auth/signin/http-response.adoc[]
+
+==== Request Fields
+
+include::{snippets}/admin/auth/signin/request-fields.adoc[]
+
+==== Response Fields
+
+include::{snippets}/admin/auth/signin/response-fields.adoc[]

--- a/be/promotion/src/main/java/woowa/promotion/admin/admin/application/AuthService.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/admin/application/AuthService.java
@@ -3,7 +3,7 @@ package woowa.promotion.admin.admin.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import woowa.promotion.admin.admin.application.dto.SignupServiceRequest;
+import woowa.promotion.admin.admin.application.dto.request.SignupServiceRequest;
 import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.admin.admin.infrastructure.AdminRepository;
 import woowa.promotion.global.exception.ApiException;

--- a/be/promotion/src/main/java/woowa/promotion/admin/admin/application/AuthService.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/admin/application/AuthService.java
@@ -3,12 +3,17 @@ package woowa.promotion.admin.admin.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import woowa.promotion.admin.admin.application.dto.request.SignInServiceRequest;
 import woowa.promotion.admin.admin.application.dto.request.SignupServiceRequest;
+import woowa.promotion.admin.admin.application.dto.response.SignInServiceResponse;
 import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.admin.admin.infrastructure.AdminRepository;
+import woowa.promotion.global.domain.jwt.JwtProvider;
 import woowa.promotion.global.exception.ApiException;
 import woowa.promotion.global.exception.domain.AdminException;
 import woowa.promotion.global.security.hash.PasswordEncoder;
+
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Transactional
@@ -17,6 +22,7 @@ public class AuthService {
 
     private final AdminRepository adminRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
 
     public void signup(SignupServiceRequest request) {
         String encryptedPassword = passwordEncoder.encrypt(request.password());
@@ -29,4 +35,16 @@ public class AuthService {
         adminRepository.save(admin);
     }
 
+    @Transactional(readOnly = true)
+    public SignInServiceResponse signIn(SignInServiceRequest request) {
+        Admin admin = adminRepository.findByEmail(request.email())
+                .orElseThrow(() -> new ApiException(AdminException.INVALID_EMAIL));
+
+        if (!admin.isSamePassword(request.password())) {
+            throw new ApiException(AdminException.INVALID_PASSWORD);
+        }
+
+        String accessToken = jwtProvider.createAccessToken(Map.of("adminId", admin.getId()));
+        return new SignInServiceResponse(accessToken);
+    }
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/admin/application/dto/request/SignInServiceRequest.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/admin/application/dto/request/SignInServiceRequest.java
@@ -1,0 +1,15 @@
+package woowa.promotion.admin.admin.application.dto.request;
+
+import woowa.promotion.admin.admin.presentation.dto.request.SignInRequest;
+
+public record SignInServiceRequest(
+        String email,
+        String password
+) {
+    public static SignInServiceRequest from(SignInRequest request) {
+        return new SignInServiceRequest(
+                request.email(),
+                request.password()
+        );
+    }
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/admin/application/dto/request/SignupServiceRequest.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/admin/application/dto/request/SignupServiceRequest.java
@@ -1,4 +1,4 @@
-package woowa.promotion.admin.admin.application.dto;
+package woowa.promotion.admin.admin.application.dto.request;
 
 import woowa.promotion.admin.admin.presentation.dto.request.SignupRequest;
 

--- a/be/promotion/src/main/java/woowa/promotion/admin/admin/application/dto/response/SignInServiceResponse.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/admin/application/dto/response/SignInServiceResponse.java
@@ -1,0 +1,6 @@
+package woowa.promotion.admin.admin.application.dto.response;
+
+public record SignInServiceResponse(
+        String accessToken
+) {
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/admin/domain/Admin.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/admin/domain/Admin.java
@@ -1,14 +1,11 @@
 package woowa.promotion.admin.admin.domain;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import woowa.promotion.global.domain.audit.AuditingFields;
+
+import javax.persistence.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,5 +33,9 @@ public class Admin extends AuditingFields {
 
     public static Admin of(String nickname, String email, String password) {
         return new Admin(nickname, email, password);
+    }
+
+    public boolean isSamePassword(String password) {
+        return this.password.equals(password);
     }
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/admin/infrastructure/AdminRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/admin/infrastructure/AdminRepository.java
@@ -3,8 +3,12 @@ package woowa.promotion.admin.admin.infrastructure;
 import org.springframework.data.jpa.repository.JpaRepository;
 import woowa.promotion.admin.admin.domain.Admin;
 
+import java.util.Optional;
+
 public interface AdminRepository extends JpaRepository<Admin, Long> {
 
     boolean existsByEmail(String email);
+
+    Optional<Admin> findByEmail(String email);
 
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/admin/presentation/AuthController.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/admin/presentation/AuthController.java
@@ -8,8 +8,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import woowa.promotion.admin.admin.application.AuthService;
+import woowa.promotion.admin.admin.application.dto.request.SignInServiceRequest;
 import woowa.promotion.admin.admin.application.dto.request.SignupServiceRequest;
+import woowa.promotion.admin.admin.presentation.dto.request.SignInRequest;
 import woowa.promotion.admin.admin.presentation.dto.request.SignupRequest;
+import woowa.promotion.admin.admin.presentation.dto.response.SignInResponse;
 
 @RequiredArgsConstructor
 @RequestMapping("/admin/auth")
@@ -25,6 +28,14 @@ public class AuthController {
         authService.signup(SignupServiceRequest.from(request));
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/sign-in")
+    public ResponseEntity<SignInResponse> signIn(
+            @RequestBody SignInRequest request
+    ) {
+        return ResponseEntity.ok()
+                .body(SignInResponse.from(authService.signIn(SignInServiceRequest.from(request))));
     }
 
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/admin/presentation/AuthController.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/admin/presentation/AuthController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import woowa.promotion.admin.admin.application.AuthService;
-import woowa.promotion.admin.admin.application.dto.SignupServiceRequest;
+import woowa.promotion.admin.admin.application.dto.request.SignupServiceRequest;
 import woowa.promotion.admin.admin.presentation.dto.request.SignupRequest;
 
 @RequiredArgsConstructor

--- a/be/promotion/src/main/java/woowa/promotion/admin/admin/presentation/dto/request/SignInRequest.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/admin/presentation/dto/request/SignInRequest.java
@@ -1,0 +1,7 @@
+package woowa.promotion.admin.admin.presentation.dto.request;
+
+public record SignInRequest(
+        String email,
+        String password
+) {
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/admin/presentation/dto/response/SignInResponse.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/admin/presentation/dto/response/SignInResponse.java
@@ -1,0 +1,11 @@
+package woowa.promotion.admin.admin.presentation.dto.response;
+
+import woowa.promotion.admin.admin.application.dto.response.SignInServiceResponse;
+
+public record SignInResponse(
+        String accessToken
+) {
+    public static SignInResponse from(SignInServiceResponse response) {
+        return new SignInResponse(response.accessToken());
+    }
+}

--- a/be/promotion/src/main/java/woowa/promotion/global/domain/jwt/JwtProvider.java
+++ b/be/promotion/src/main/java/woowa/promotion/global/domain/jwt/JwtProvider.java
@@ -1,18 +1,15 @@
 package woowa.promotion.global.domain.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
-import java.security.Key;
-import java.util.Date;
-import java.util.Map;
 import org.springframework.stereotype.Component;
 import woowa.promotion.global.exception.ApiException;
 import woowa.promotion.global.exception.domain.AuthorizationException;
 import woowa.promotion.global.properties.JwtProperties;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
 
 @Component
 public class JwtProvider {
@@ -33,7 +30,7 @@ public class JwtProvider {
                 .compact();
     }
 
-    public Date getExpireDate(long expirationTime) {
+    private Date getExpireDate(long expirationTime) {
         return new Date(System.currentTimeMillis() + expirationTime);
     }
 

--- a/be/promotion/src/main/java/woowa/promotion/global/exception/domain/AdminException.java
+++ b/be/promotion/src/main/java/woowa/promotion/global/exception/domain/AdminException.java
@@ -9,7 +9,9 @@ import woowa.promotion.global.exception.CustomException;
 @RequiredArgsConstructor
 public enum AdminException implements CustomException {
 
-    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "중복된 이메일입니다.");
+    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "중복된 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    INVALID_EMAIL(HttpStatus.UNAUTHORIZED, "존재하지 않는 이메일입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/be/promotion/src/test/java/woowa/promotion/acceptance/AdminAcceptanceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/acceptance/AdminAcceptanceTest.java
@@ -9,6 +9,7 @@ import woowa.promotion.fixture.FixtureFactory;
 import woowa.promotion.util.AcceptanceTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("[인수테스트] 관리자")
 public class AdminAcceptanceTest extends AcceptanceTest {
@@ -31,4 +32,28 @@ public class AdminAcceptanceTest extends AcceptanceTest {
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
+
+    @DisplayName("관리자가 로그인에 성공해 토큰을 발급받는다.")
+    @Test
+    void signIn() {
+        // given
+        supportRepository.save(FixtureFactory.createAdmin());
+        var request = RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(FixtureFactory.createSignInRequest());
+
+        // when
+        var response = request
+                .when().post("/admin/auth/sign-in")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getString("accessToken")).isNotBlank()
+        );
+    }
+
 }

--- a/be/promotion/src/test/java/woowa/promotion/acceptance/MemberAcceptanceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/acceptance/MemberAcceptanceTest.java
@@ -1,10 +1,7 @@
 package woowa.promotion.acceptance;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static woowa.promotion.fixture.UserFixture.유저_June;
-
 import io.restassured.RestAssured;
-import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -14,7 +11,32 @@ import woowa.promotion.app.member.presentation.dto.request.SignInRequest;
 import woowa.promotion.app.member.presentation.dto.request.SignUpRequest;
 import woowa.promotion.util.AcceptanceTest;
 
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static woowa.promotion.fixture.UserFixture.유저_June;
+
+@DisplayName("[인수테스트] 회원")
 public class MemberAcceptanceTest extends AcceptanceTest {
+
+    private static Stream<Arguments> providerSignupUser() {
+        return Stream.of(
+                Arguments.of(
+                        유저_June.getEmail(),
+                        유저_June.getNickname(),
+                        유저_June.getPassword()
+                )
+        );
+    }
+
+    private static Stream<Arguments> providerSigninUser() {
+        return Stream.of(
+                Arguments.of(
+                        유저_June.getEmail(),
+                        유저_June.getPassword()
+                )
+        );
+    }
 
     @ParameterizedTest
     @MethodSource("providerSignupUser")
@@ -56,25 +78,6 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    private static Stream<Arguments> providerSignupUser() {
-        return Stream.of(
-                Arguments.of(
-                        유저_June.getEmail(),
-                        유저_June.getNickname(),
-                        유저_June.getPassword()
-                )
-        );
-    }
-
-    private static Stream<Arguments> providerSigninUser() {
-        return Stream.of(
-                Arguments.of(
-                        유저_June.getEmail(),
-                        유저_June.getPassword()
-                )
-        );
     }
 
 }

--- a/be/promotion/src/test/java/woowa/promotion/admin/admin/application/AuthServiceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/admin/application/AuthServiceTest.java
@@ -3,7 +3,9 @@ package woowa.promotion.admin.admin.application;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import woowa.promotion.admin.admin.application.dto.request.SignInServiceRequest;
 import woowa.promotion.admin.admin.application.dto.request.SignupServiceRequest;
+import woowa.promotion.admin.admin.application.dto.response.SignInServiceResponse;
 import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.fixture.FixtureFactory;
 import woowa.promotion.global.security.hash.PasswordEncoder;
@@ -38,5 +40,19 @@ class AuthServiceTest extends ApplicationTest {
                 () -> assertThat(admin).isNotNull(),
                 () -> assertThat(admin.getPassword()).isEqualTo(encrypted)
         );
+    }
+
+    @DisplayName("관리자가 로그인에 성공하며 액세스 토큰을 발급받는다.")
+    @Test
+    void signIn() {
+        // given
+        SignInServiceRequest request = FixtureFactory.createSignInServiceRequest();
+        supportRepository.save(FixtureFactory.createAdmin());
+
+        // when
+        SignInServiceResponse response = authService.signIn(request);
+
+        // then
+        assertThat(response.accessToken()).isNotBlank();
     }
 }

--- a/be/promotion/src/test/java/woowa/promotion/admin/admin/application/AuthServiceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/admin/application/AuthServiceTest.java
@@ -1,6 +1,7 @@
 package woowa.promotion.admin.admin.application;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import woowa.promotion.admin.admin.application.dto.request.SignInServiceRequest;
@@ -24,60 +25,70 @@ class AuthServiceTest extends ApplicationTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
-    @DisplayName("관리자 회원가입에 성공하며 암호화된 비밀번호가 저장된다.")
-    @Test
-    void signup() {
-        // given
-        SignupServiceRequest request = FixtureFactory.createSignupServiceRequest();
+    @DisplayName("회원가입")
+    @Nested
+    class Signup {
 
-        // when
-        authService.signup(request);
+        @DisplayName("관리자 회원가입에 성공하며 암호화된 비밀번호가 저장된다.")
+        @Test
+        void signup() {
+            // given
+            SignupServiceRequest request = FixtureFactory.createSignupServiceRequest();
 
-        String encrypted = passwordEncoder.encrypt(request.password());
+            // when
+            authService.signup(request);
 
-        // then
-        Admin admin = supportRepository.findAll(Admin.class).get(0);
+            String encrypted = passwordEncoder.encrypt(request.password());
 
-        assertAll(
-                () -> assertThat(admin).isNotNull(),
-                () -> assertThat(admin.getPassword()).isEqualTo(encrypted)
-        );
+            // then
+            Admin admin = supportRepository.findAll(Admin.class).get(0);
+
+            assertAll(
+                    () -> assertThat(admin).isNotNull(),
+                    () -> assertThat(admin.getPassword()).isEqualTo(encrypted)
+            );
+        }
+
+        @DisplayName("중복된 회원가입 데이터가 주어지면 예외가 발생한다.")
+        @Test
+        void duplicatedSignupData_whenSignup_thenThrowsException() {
+            // given
+            SignupServiceRequest request = FixtureFactory.createSignupServiceRequest();
+            supportRepository.save(FixtureFactory.createAdmin());
+
+            // when & then
+            assertThatThrownBy(() -> authService.signup(request))
+                    .isInstanceOf(ApiException.class);
+        }
     }
 
-    @DisplayName("중복된 회원가입 데이터가 주어지면 예외가 발생한다.")
-    @Test
-    void duplicatedSignupData_whenSignup_thenThrowsException() {
-        // given
-        SignupServiceRequest request = FixtureFactory.createSignupServiceRequest();
-        supportRepository.save(FixtureFactory.createAdmin());
+    @DisplayName("로그인")
+    @Nested
+    class SignIn {
 
-        // when & then
-        assertThatThrownBy(() -> authService.signup(request))
-                .isInstanceOf(ApiException.class);
-    }
+        @DisplayName("관리자가 로그인에 성공하며 액세스 토큰을 발급받는다.")
+        @Test
+        void signIn() {
+            // given
+            SignInServiceRequest request = FixtureFactory.createSignInServiceRequest();
+            supportRepository.save(FixtureFactory.createAdmin());
 
-    @DisplayName("관리자가 로그인에 성공하며 액세스 토큰을 발급받는다.")
-    @Test
-    void signIn() {
-        // given
-        SignInServiceRequest request = FixtureFactory.createSignInServiceRequest();
-        supportRepository.save(FixtureFactory.createAdmin());
+            // when
+            SignInServiceResponse response = authService.signIn(request);
 
-        // when
-        SignInServiceResponse response = authService.signIn(request);
+            // then
+            assertThat(response.accessToken()).isNotBlank();
+        }
 
-        // then
-        assertThat(response.accessToken()).isNotBlank();
-    }
+        @DisplayName("유효하지 않은 로그인 데이터가 주어지면 예외가 발생한다.")
+        @Test
+        void givenInvalidSignInData_whenSignIn_thenThrowsException() {
+            // given
+            SignInServiceRequest request = FixtureFactory.createSignInServiceRequest();
 
-    @DisplayName("유효하지 않은 로그인 데이터가 주어지면 예외가 발생한다.")
-    @Test
-    void givenInvalidSignInData_whenSignIn_thenThrowsException() {
-        // given
-        SignInServiceRequest request = FixtureFactory.createSignInServiceRequest();
-
-        // when & then
-        assertThatThrownBy(() -> authService.signIn(request))
-                .isInstanceOf(ApiException.class);
+            // when & then
+            assertThatThrownBy(() -> authService.signIn(request))
+                    .isInstanceOf(ApiException.class);
+        }
     }
 }

--- a/be/promotion/src/test/java/woowa/promotion/admin/admin/application/AuthServiceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/admin/application/AuthServiceTest.java
@@ -1,16 +1,16 @@
 package woowa.promotion.admin.admin.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import woowa.promotion.admin.admin.application.dto.SignupServiceRequest;
+import woowa.promotion.admin.admin.application.dto.request.SignupServiceRequest;
 import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.fixture.FixtureFactory;
 import woowa.promotion.global.security.hash.PasswordEncoder;
 import woowa.promotion.util.ApplicationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("[비즈니스 로직 테스트] 관리자")
 class AuthServiceTest extends ApplicationTest {

--- a/be/promotion/src/test/java/woowa/promotion/admin/admin/application/AuthServiceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/admin/application/AuthServiceTest.java
@@ -8,10 +8,12 @@ import woowa.promotion.admin.admin.application.dto.request.SignupServiceRequest;
 import woowa.promotion.admin.admin.application.dto.response.SignInServiceResponse;
 import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.fixture.FixtureFactory;
+import woowa.promotion.global.exception.ApiException;
 import woowa.promotion.global.security.hash.PasswordEncoder;
 import woowa.promotion.util.ApplicationTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("[비즈니스 로직 테스트] 관리자")
@@ -42,6 +44,18 @@ class AuthServiceTest extends ApplicationTest {
         );
     }
 
+    @DisplayName("중복된 회원가입 데이터가 주어지면 예외가 발생한다.")
+    @Test
+    void duplicatedSignupData_whenSignup_thenThrowsException() {
+        // given
+        SignupServiceRequest request = FixtureFactory.createSignupServiceRequest();
+        supportRepository.save(FixtureFactory.createAdmin());
+
+        // when & then
+        assertThatThrownBy(() -> authService.signup(request))
+                .isInstanceOf(ApiException.class);
+    }
+
     @DisplayName("관리자가 로그인에 성공하며 액세스 토큰을 발급받는다.")
     @Test
     void signIn() {
@@ -54,5 +68,16 @@ class AuthServiceTest extends ApplicationTest {
 
         // then
         assertThat(response.accessToken()).isNotBlank();
+    }
+
+    @DisplayName("유효하지 않은 로그인 데이터가 주어지면 예외가 발생한다.")
+    @Test
+    void givenInvalidSignInData_whenSignIn_thenThrowsException() {
+        // given
+        SignInServiceRequest request = FixtureFactory.createSignInServiceRequest();
+
+        // when & then
+        assertThatThrownBy(() -> authService.signIn(request))
+                .isInstanceOf(ApiException.class);
     }
 }

--- a/be/promotion/src/test/java/woowa/promotion/admin/documentation/AuthDocumentationTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/documentation/AuthDocumentationTest.java
@@ -5,16 +5,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import woowa.promotion.admin.admin.application.AuthService;
-import woowa.promotion.admin.admin.application.dto.request.SignupServiceRequest;
+import woowa.promotion.admin.admin.application.dto.request.SignInServiceRequest;
 import woowa.promotion.fixture.FixtureFactory;
 import woowa.promotion.util.DocumentationTest;
 
-import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("[RESTDocs] 관리자 인증 API")
@@ -27,7 +27,7 @@ public class AuthDocumentationTest extends DocumentationTest {
     @Test
     void signup() throws Exception {
         // given
-        SignupServiceRequest signupData = FixtureFactory.createSignupServiceRequest();
+        var signupData = FixtureFactory.createSignupServiceRequest();
         willDoNothing().given(authService).signup(signupData);
 
         // when
@@ -47,6 +47,37 @@ public class AuthDocumentationTest extends DocumentationTest {
                                 fieldWithPath("email").description("이메일"),
                                 fieldWithPath("nickname").description("닉네임"),
                                 fieldWithPath("password").description("비밀번호")
+                        )
+                ));
+    }
+
+    @DisplayName("관리자 로그인")
+    @Test
+    void signIn() throws Exception {
+        // given
+        var signInData = FixtureFactory.createSignInRequest();
+        given(authService.signIn(any(SignInServiceRequest.class))).willReturn(FixtureFactory.createSignInServiceResponse());
+
+        // when
+        var response = mockMvc.perform(post("/admin/auth/sign-in")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(signInData)));
+
+        // then
+        var resultActions = response.andExpect(status().isOk())
+                .andExpect(jsonPath("accessToken").isNotEmpty());
+
+        // docs
+        resultActions
+                .andDo(document("admin/auth/signin",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("email").description("로그인 이메일"),
+                                fieldWithPath("password").description("로그인 비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("accessToken").description("액세스 토큰")
                         )
                 ));
     }

--- a/be/promotion/src/test/java/woowa/promotion/admin/documentation/AuthDocumentationTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/documentation/AuthDocumentationTest.java
@@ -1,23 +1,21 @@
 package woowa.promotion.admin.documentation;
 
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import woowa.promotion.admin.admin.application.AuthService;
-import woowa.promotion.admin.admin.application.dto.SignupServiceRequest;
+import woowa.promotion.admin.admin.application.dto.request.SignupServiceRequest;
 import woowa.promotion.fixture.FixtureFactory;
 import woowa.promotion.util.DocumentationTest;
+
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("[RESTDocs] 관리자 인증 API")
 public class AuthDocumentationTest extends DocumentationTest {

--- a/be/promotion/src/test/java/woowa/promotion/app/member/application/MemberServiceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/app/member/application/MemberServiceTest.java
@@ -1,9 +1,6 @@
 package woowa.promotion.app.member.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static woowa.promotion.fixture.UserFixture.유저_June;
-
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import woowa.promotion.app.member.application.dto.request.SignInServiceRequest;
@@ -16,6 +13,11 @@ import woowa.promotion.global.exception.domain.MemberException;
 import woowa.promotion.global.security.hash.PasswordEncoder;
 import woowa.promotion.util.ApplicationTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static woowa.promotion.fixture.UserFixture.유저_June;
+
+@DisplayName("[비즈니스 로직 테스트] 회원")
 class MemberServiceTest extends ApplicationTest {
 
     @Autowired

--- a/be/promotion/src/test/java/woowa/promotion/fixture/FixtureFactory.java
+++ b/be/promotion/src/test/java/woowa/promotion/fixture/FixtureFactory.java
@@ -1,6 +1,6 @@
 package woowa.promotion.fixture;
 
-import woowa.promotion.admin.admin.application.dto.SignupServiceRequest;
+import woowa.promotion.admin.admin.application.dto.request.SignupServiceRequest;
 import woowa.promotion.admin.admin.presentation.dto.request.SignupRequest;
 import woowa.promotion.app.member.domain.Member;
 

--- a/be/promotion/src/test/java/woowa/promotion/fixture/FixtureFactory.java
+++ b/be/promotion/src/test/java/woowa/promotion/fixture/FixtureFactory.java
@@ -1,6 +1,10 @@
 package woowa.promotion.fixture;
 
+import woowa.promotion.admin.admin.application.dto.request.SignInServiceRequest;
 import woowa.promotion.admin.admin.application.dto.request.SignupServiceRequest;
+import woowa.promotion.admin.admin.application.dto.response.SignInServiceResponse;
+import woowa.promotion.admin.admin.domain.Admin;
+import woowa.promotion.admin.admin.presentation.dto.request.SignInRequest;
 import woowa.promotion.admin.admin.presentation.dto.request.SignupRequest;
 import woowa.promotion.app.member.domain.Member;
 
@@ -26,4 +30,25 @@ public class FixtureFactory {
         );
     }
 
+    public static SignInRequest createSignInRequest() {
+        return new SignInRequest(
+                "bruni@woowa.com",
+                "1234"
+        );
+    }
+
+    public static SignInServiceRequest createSignInServiceRequest() {
+        return new SignInServiceRequest(
+                "bruni@woowa.com",
+                "1234"
+        );
+    }
+
+    public static SignInServiceResponse createSignInServiceResponse() {
+        return new SignInServiceResponse("accessToken");
+    }
+
+    public static Admin createAdmin() {
+        return Admin.of("브루니", "bruni@woowa.com", "1234");
+    }
 }

--- a/be/promotion/src/test/java/woowa/promotion/global/domain/jwt/JwtProviderTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/global/domain/jwt/JwtProviderTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@DisplayName("JwtProvider 단위 테스트")
 class JwtProviderTest {
 
     private static final String SECRET_KEY = "1231231231231231231231231231231231312312312312312312312312312312";

--- a/be/promotion/src/test/java/woowa/promotion/global/domain/jwt/JwtProviderTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/global/domain/jwt/JwtProviderTest.java
@@ -1,0 +1,67 @@
+package woowa.promotion.global.domain.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import woowa.promotion.global.exception.ApiException;
+import woowa.promotion.global.properties.JwtProperties;
+
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtProviderTest {
+
+    private static final String SECRET_KEY = "1231231231231231231231231231231231312312312312312312312312312312";
+
+    private final JwtProvider jwtProvider = new JwtProvider(new JwtProperties(SECRET_KEY));
+
+    @DisplayName("액세스 토큰을 생성하는데 성공한다.")
+    @Test
+    void createAccessToken() {
+        // given
+        Map<String, Object> claim = Map.of("memberId", 1L);
+
+        // when
+        String accessToken = jwtProvider.createAccessToken(claim);
+
+        // then
+        assertThat(accessToken).isNotBlank();
+    }
+
+    @DisplayName("액세스 토큰에서 클레임을 추출하는데 성공한다.")
+    @Test
+    void extractClaimsFromAccessToken() {
+        // given
+        Map<String, Object> claim = Map.of("memberId", 1L);
+        String accessToken = jwtProvider.createAccessToken(claim);
+
+        // when
+        Claims claims = jwtProvider.extractClaims(accessToken);
+
+        // then
+        assertThat(Long.parseLong(claims.get("memberId").toString())).isEqualTo(1L);
+    }
+
+    @DisplayName("만료된 액세스 토큰이 주어지면 클레임 추출시 예외를 던진다.")
+    @Test
+    void validateAccessToken() {
+        // given
+        Map<String, Object> claim = Map.of("memberId", 1L);
+
+        String expiredToken = Jwts.builder()
+                .setClaims(claim)
+                .setExpiration(new Date(System.currentTimeMillis() - 1))
+                .signWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()))
+                .compact();
+
+        // when & then
+        assertThatThrownBy(() -> jwtProvider.extractClaims(expiredToken))
+                .isInstanceOf(ApiException.class);
+    }
+
+}

--- a/be/promotion/src/test/java/woowa/promotion/global/security/hash/SHA256Test.java
+++ b/be/promotion/src/test/java/woowa/promotion/global/security/hash/SHA256Test.java
@@ -1,12 +1,13 @@
 package woowa.promotion.global.security.hash;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import woowa.promotion.global.exception.ApiException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("SHA256 단위 테스트")
 class SHA256Test {
 
     private SHA256 sha256 = new SHA256();

--- a/be/promotion/src/test/java/woowa/promotion/global/util/HttpAuthorizationUtilTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/global/util/HttpAuthorizationUtilTest.java
@@ -1,0 +1,27 @@
+package woowa.promotion.global.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("HttpAuthorizationUtil 단위 테스트")
+class HttpAuthorizationUtilTest {
+
+    @DisplayName("ServletRequest의 Authorization 헤더에서 액세스 토큰을 추출하는데 성공한다.")
+    @Test
+    void extractAccessToken() {
+        // given
+        var request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer accessToken");
+
+        // when
+        String accessToken = HttpAuthorizationUtil.extractAccessToken(request);
+
+        // then
+        assertThat(accessToken).isEqualTo("accessToken");
+    }
+
+}

--- a/be/promotion/src/test/java/woowa/promotion/util/DocumentationTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/util/DocumentationTest.java
@@ -1,6 +1,7 @@
 package woowa.promotion.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -8,6 +9,14 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import woowa.promotion.admin.admin.application.AuthService;
 import woowa.promotion.admin.admin.presentation.AuthController;
+import woowa.promotion.global.domain.jwt.JwtProvider;
+import woowa.promotion.global.interceptor.AuthInterceptor;
+import woowa.promotion.global.resolver.AuthArgumentResolver;
+
+import java.util.Map;
+
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
 
 @MockBean({
         AuthService.class
@@ -22,5 +31,19 @@ public abstract class DocumentationTest {
     protected MockMvc mockMvc;
     @Autowired
     protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected JwtProvider jwtProvider;
+    @MockBean
+    protected AuthInterceptor authInterceptor;
+    @MockBean
+    protected AuthArgumentResolver authArgumentResolver;
+
+    @BeforeEach
+    void setUp() {
+        given(jwtProvider.createAccessToken(any(Map.class))).willReturn("accessToken");
+        given(authInterceptor.preHandle(any(), any(), any())).willReturn(true);
+        given(authArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(1L);
+    }
 
 }


### PR DESCRIPTION
## ✨ Issue
- #28 

## 🔑 Key changes
- 관리자 로그인
  - 이메일 존재하지 않을시 에러
  - 비밀번호 불일치시 에러
- 테스트코드 작성

## 👋 To reviewers
인터셉터에서 `Admin`을 넣는 로직은 추후 이슈를 따로 빼도록 하겠습니다~!
