### PR TITLE
[BE][feat] 쿠폰 그룹 생성 기능 구현

### DIFF
--- a/be/promotion/src/main/java/woowa/promotion/admin/admin/application/AdminService.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/admin/application/AdminService.java
@@ -17,7 +17,7 @@ import woowa.promotion.global.security.hash.PasswordEncoder;
 @RequiredArgsConstructor
 @Transactional
 @Service
-public class AuthService {
+public class AdminService {
 
     private final AdminRepository adminRepository;
     private final PasswordEncoder passwordEncoder;

--- a/be/promotion/src/main/java/woowa/promotion/admin/admin/presentation/AuthController.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/admin/presentation/AuthController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import woowa.promotion.admin.admin.application.AuthService;
+import woowa.promotion.admin.admin.application.AdminService;
 import woowa.promotion.admin.admin.application.dto.request.SignInServiceRequest;
 import woowa.promotion.admin.admin.application.dto.request.SignupServiceRequest;
 import woowa.promotion.admin.admin.presentation.dto.request.SignInRequest;
@@ -19,13 +19,13 @@ import woowa.promotion.admin.admin.presentation.dto.response.SignInResponse;
 @RestController
 public class AuthController {
 
-    private final AuthService authService;
+    private final AdminService adminService;
 
     @PostMapping("/sign-up")
     public ResponseEntity<Void> signup(
             @RequestBody SignupRequest request
     ) {
-        authService.signup(SignupServiceRequest.from(request));
+        adminService.signup(SignupServiceRequest.from(request));
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -35,7 +35,7 @@ public class AuthController {
             @RequestBody SignInRequest request
     ) {
         return ResponseEntity.ok()
-                .body(SignInResponse.from(authService.signIn(SignInServiceRequest.from(request))));
+                .body(SignInResponse.from(adminService.signIn(SignInServiceRequest.from(request))));
     }
 
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon/domain/Coupon.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon/domain/Coupon.java
@@ -11,6 +11,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import woowa.promotion.admin.coupon_group.domain.CouponGroup;
@@ -44,5 +45,14 @@ public class Coupon extends AuditingFields {
     @JoinColumn(name = "coupon_group_id", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private CouponGroup couponGroup;
-    
+
+    @Builder
+    private Coupon(String title, Integer discount, CouponType type, Integer initialQuantity, CouponGroup couponGroup) {
+        this.title = title;
+        this.discount = discount;
+        this.type = type;
+        this.initialQuantity = initialQuantity;
+        this.remainQuantity = initialQuantity;
+        this.couponGroup = couponGroup;
+    }
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon/domain/CouponType.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon/domain/CouponType.java
@@ -1,7 +1,17 @@
 package woowa.promotion.admin.coupon.domain;
 
+import java.util.Arrays;
+import woowa.promotion.global.exception.ApiException;
+import woowa.promotion.global.exception.domain.CouponException;
+
 public enum CouponType {
 
-    FIXED, RATE
+    FIXED, RATE;
 
+    public static CouponType from(String type) {
+        return Arrays.stream(CouponType.values())
+                .filter(couponType -> couponType.name().equalsIgnoreCase(type))
+                .findAny()
+                .orElseThrow(() -> new ApiException(CouponException.INVALID_COUPON_TYPE));
+    }
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon/infrastructure/CouponRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon/infrastructure/CouponRepository.java
@@ -1,0 +1,7 @@
+package woowa.promotion.admin.coupon.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import woowa.promotion.admin.coupon.domain.Coupon;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/application/CouponGroupService.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/application/CouponGroupService.java
@@ -1,0 +1,28 @@
+package woowa.promotion.admin.coupon_group.application;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import woowa.promotion.admin.coupon.domain.Coupon;
+import woowa.promotion.admin.coupon.infrastructure.CouponRepository;
+import woowa.promotion.admin.coupon_group.domain.CouponGroup;
+import woowa.promotion.admin.coupon_group.infrastructure.CouponGroupRepository;
+import woowa.promotion.admin.coupon_group.presentation.dto.CouponGroupCreateRequest;
+
+@Service
+@RequiredArgsConstructor
+public class CouponGroupService {
+
+    private final CouponGroupRepository couponGroupRepository;
+    private final CouponRepository couponRepository;
+
+    @Transactional
+    public void saveCouponGroup(CouponGroupCreateRequest request) {
+        CouponGroup couponGroup = request.toCouponGroup();
+        couponGroupRepository.save(couponGroup);
+
+        List<Coupon> coupons = request.toCoupons(couponGroup);
+        couponRepository.saveAll(coupons);
+    }
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/application/CouponGroupService.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/application/CouponGroupService.java
@@ -13,6 +13,7 @@ import woowa.promotion.admin.coupon_group.presentation.dto.CouponGroupCreateRequ
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CouponGroupService {
 
     private final CouponGroupRepository couponGroupRepository;

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/application/CouponGroupService.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/application/CouponGroupService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.admin.coupon.domain.Coupon;
 import woowa.promotion.admin.coupon.infrastructure.CouponRepository;
 import woowa.promotion.admin.coupon_group.domain.CouponGroup;
@@ -18,8 +19,8 @@ public class CouponGroupService {
     private final CouponRepository couponRepository;
 
     @Transactional
-    public void saveCouponGroup(CouponGroupCreateRequest request) {
-        CouponGroup couponGroup = request.toCouponGroup();
+    public void saveCouponGroup(CouponGroupCreateRequest request, Admin loginAdmin) {
+        CouponGroup couponGroup = request.toCouponGroup(loginAdmin.getNickname());
         couponGroupRepository.save(couponGroup);
 
         List<Coupon> coupons = request.toCoupons(couponGroup);

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/domain/CouponGroup.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/domain/CouponGroup.java
@@ -32,7 +32,7 @@ public class CouponGroup {
     @Column(nullable = false)
     private Instant finishedAt;
 
-    @JoinColumn(name = "promotion_id", nullable = false)
+    @JoinColumn(name = "promotion_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Promotion promotion;
     

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/domain/CouponGroup.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/domain/CouponGroup.java
@@ -10,6 +10,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import woowa.promotion.admin.promotion.domain.Promotion;
@@ -39,7 +40,8 @@ public class CouponGroup {
     @ManyToOne(fetch = FetchType.LAZY)
     private Promotion promotion;
 
-    public CouponGroup(String title, Instant startedAt, Instant finishedAt, String adminNickname) {
+    @Builder
+    private CouponGroup(String title, Instant startedAt, Instant finishedAt, String adminNickname) {
         this.title = title;
         this.startedAt = startedAt;
         this.finishedAt = finishedAt;

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/domain/CouponGroup.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/domain/CouponGroup.java
@@ -35,5 +35,10 @@ public class CouponGroup {
     @JoinColumn(name = "promotion_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Promotion promotion;
-    
+
+    public CouponGroup(String title, Instant startedAt, Instant finishedAt) {
+        this.title = title;
+        this.startedAt = startedAt;
+        this.finishedAt = finishedAt;
+    }
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/domain/CouponGroup.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/domain/CouponGroup.java
@@ -32,13 +32,17 @@ public class CouponGroup {
     @Column(nullable = false)
     private Instant finishedAt;
 
+    @Column(nullable = false)
+    private String adminNickname;
+
     @JoinColumn(name = "promotion_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Promotion promotion;
 
-    public CouponGroup(String title, Instant startedAt, Instant finishedAt) {
+    public CouponGroup(String title, Instant startedAt, Instant finishedAt, String adminNickname) {
         this.title = title;
         this.startedAt = startedAt;
         this.finishedAt = finishedAt;
+        this.adminNickname = adminNickname;
     }
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/infrastructure/CouponGroupRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/infrastructure/CouponGroupRepository.java
@@ -1,0 +1,7 @@
+package woowa.promotion.admin.coupon_group.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import woowa.promotion.admin.coupon_group.domain.CouponGroup;
+
+public interface CouponGroupRepository extends JpaRepository<CouponGroup, Long> {
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/CouponGroupController.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/CouponGroupController.java
@@ -1,0 +1,28 @@
+package woowa.promotion.admin.coupon_group.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import woowa.promotion.admin.coupon_group.application.CouponGroupService;
+import woowa.promotion.admin.coupon_group.presentation.dto.CouponGroupCreateRequest;
+
+@RequiredArgsConstructor
+@RequestMapping("/admin/coupon-groups")
+@RestController
+public class CouponGroupController {
+
+    private final CouponGroupService couponGroupService;
+
+    @PostMapping
+    public ResponseEntity<Void> createCouponGroups (
+            @RequestBody CouponGroupCreateRequest request
+    ) {
+        couponGroupService.saveCouponGroup(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/CouponGroupController.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/CouponGroupController.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.admin.coupon_group.application.CouponGroupService;
 import woowa.promotion.admin.coupon_group.presentation.dto.CouponGroupCreateRequest;
+import woowa.promotion.global.resolver.Authentication;
 
 @RequiredArgsConstructor
 @RequestMapping("/admin/coupon-groups")
@@ -18,10 +20,11 @@ public class CouponGroupController {
     private final CouponGroupService couponGroupService;
 
     @PostMapping
-    public ResponseEntity<Void> createCouponGroups (
-            @RequestBody CouponGroupCreateRequest request
+    public ResponseEntity<Void> createCouponGroups(
+            @RequestBody CouponGroupCreateRequest request,
+            @Authentication Admin loginAdmin
     ) {
-        couponGroupService.saveCouponGroup(request);
+        couponGroupService.saveCouponGroup(request, loginAdmin);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/dto/CouponGroupCreateRequest.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/dto/CouponGroupCreateRequest.java
@@ -1,0 +1,47 @@
+package woowa.promotion.admin.coupon_group.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+import woowa.promotion.admin.coupon.domain.Coupon;
+import woowa.promotion.admin.coupon.domain.CouponType;
+import woowa.promotion.admin.coupon_group.domain.CouponGroup;
+
+public record CouponGroupCreateRequest(
+
+        String title,
+        Instant startedAt,
+        Instant finishedAt,
+
+        @JsonProperty("coupons")
+        List<CouponDto> couponDtos
+) {
+    public record CouponDto(
+            String title,
+            String type,
+            int discount,
+            int initialQuantity
+    ) {
+    }
+
+    public CouponGroup toCouponGroup() {
+        return new CouponGroup(title, startedAt, finishedAt);
+    }
+
+    public List<Coupon> toCoupons(CouponGroup couponGroup) {
+        return couponDtos.stream()
+                .map(couponDto -> toCoupon(couponDto, couponGroup))
+                .collect(Collectors.toList());
+    }
+
+    private Coupon toCoupon(CouponDto couponDto, CouponGroup couponGroup) {
+        return Coupon.builder()
+                .title(couponDto.title())
+                .discount(couponDto.discount())
+                .type(CouponType.from(couponDto.type()))
+                .initialQuantity(couponDto.initialQuantity())
+                .couponGroup(couponGroup)
+                .build();
+    }
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/dto/CouponGroupCreateRequest.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/dto/CouponGroupCreateRequest.java
@@ -25,8 +25,8 @@ public record CouponGroupCreateRequest(
     ) {
     }
 
-    public CouponGroup toCouponGroup() {
-        return new CouponGroup(title, startedAt, finishedAt);
+    public CouponGroup toCouponGroup(String adminNickname) {
+        return new CouponGroup(title, startedAt, finishedAt, adminNickname);
     }
 
     public List<Coupon> toCoupons(CouponGroup couponGroup) {

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/dto/CouponGroupCreateRequest.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/dto/CouponGroupCreateRequest.java
@@ -26,7 +26,12 @@ public record CouponGroupCreateRequest(
     }
 
     public CouponGroup toCouponGroup(String adminNickname) {
-        return new CouponGroup(title, startedAt, finishedAt, adminNickname);
+        return CouponGroup.builder()
+                .title(title)
+                .startedAt(startedAt)
+                .finishedAt(finishedAt)
+                .adminNickname(adminNickname)
+                .build();
     }
 
     public List<Coupon> toCoupons(CouponGroup couponGroup) {

--- a/be/promotion/src/main/java/woowa/promotion/global/exception/domain/CouponException.java
+++ b/be/promotion/src/main/java/woowa/promotion/global/exception/domain/CouponException.java
@@ -1,0 +1,17 @@
+package woowa.promotion.global.exception.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import woowa.promotion.global.exception.CustomException;
+
+@Getter
+@RequiredArgsConstructor
+public enum CouponException implements CustomException {
+
+    INVALID_COUPON_TYPE(HttpStatus.BAD_REQUEST, "잘못된 쿠폰 타입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/be/promotion/src/main/java/woowa/promotion/global/exception/domain/CouponException.java
+++ b/be/promotion/src/main/java/woowa/promotion/global/exception/domain/CouponException.java
@@ -9,7 +9,7 @@ import woowa.promotion.global.exception.CustomException;
 @RequiredArgsConstructor
 public enum CouponException implements CustomException {
 
-    INVALID_COUPON_TYPE(HttpStatus.BAD_REQUEST, "잘못된 쿠폰 타입니다.");
+    INVALID_COUPON_TYPE(HttpStatus.BAD_REQUEST, "잘못된 쿠폰 타입입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/be/promotion/src/main/resources/schema.sql
+++ b/be/promotion/src/main/resources/schema.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS member
 (
     id         BIGINT       NOT NULL AUTO_INCREMENT,
-    nickname   VARCHAR(45)  NOT NULL,
+    nickname   VARCHAR(45)  NOT NULL UNIQUE,
     email      VARCHAR(45)  NOT NULL,
     created_at TIMESTAMP    NOT NULL,
     password   VARCHAR(500) NOT NULL,
@@ -50,11 +50,12 @@ CREATE TABLE IF NOT EXISTS promotion_option
 
 CREATE TABLE IF NOT EXISTS coupon_group
 (
-    id           BIGINT      NOT NULL AUTO_INCREMENT,
-    title        VARCHAR(50) NOT NULL,
-    started_at   TIMESTAMP   NOT NULL,
-    finished_at  TIMESTAMP   NOT NULL,
-    promotion_id BIGINT      NULL,
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    title          VARCHAR(50)  NOT NULL,
+    started_at     TIMESTAMP    NOT NULL,
+    finished_at    TIMESTAMP    NOT NULL,
+    admin_nickname VARCHAR(45) NOT NULL,
+    promotion_id   BIGINT       NULL,
     PRIMARY KEY (id)
 );
 

--- a/be/promotion/src/main/resources/schema.sql
+++ b/be/promotion/src/main/resources/schema.sql
@@ -54,7 +54,7 @@ CREATE TABLE IF NOT EXISTS coupon_group
     title        VARCHAR(50) NOT NULL,
     started_at   TIMESTAMP   NOT NULL,
     finished_at  TIMESTAMP   NOT NULL,
-    promotion_id BIGINT      NOT NULL,
+    promotion_id BIGINT      NULL,
     PRIMARY KEY (id)
 );
 

--- a/be/promotion/src/test/java/woowa/promotion/acceptance/CouponGroupAcceptanceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/acceptance/CouponGroupAcceptanceTest.java
@@ -18,8 +18,8 @@ public class CouponGroupAcceptanceTest extends AcceptanceTest {
     @DisplayName("쿠폰 그룹 생성에 성공한다.")
     @Test
     void createCouponGroups() {
+        // given
         Admin admin = supportRepository.save(Admin.of("nickname", "email", "password"));
-
         String accessToken = jwtProvider.createAccessToken(Map.of("adminId", admin.getId()));
 
         var request = RestAssured

--- a/be/promotion/src/test/java/woowa/promotion/acceptance/CouponGroupAcceptanceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/acceptance/CouponGroupAcceptanceTest.java
@@ -1,0 +1,40 @@
+package woowa.promotion.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import woowa.promotion.admin.admin.domain.Admin;
+import woowa.promotion.fixture.FixtureFactory;
+import woowa.promotion.util.AcceptanceTest;
+
+@DisplayName("[인수테스트] 관리자 - 쿠폰 그룹")
+public class CouponGroupAcceptanceTest extends AcceptanceTest {
+
+    @DisplayName("쿠폰 그룹 생성에 성공한다.")
+    @Test
+    void createCouponGroups() {
+        Admin admin = supportRepository.save(Admin.of("nickname", "email", "password"));
+
+        String accessToken = jwtProvider.createAccessToken(Map.of("adminId", admin.getId()));
+
+        var request = RestAssured
+                .given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(FixtureFactory.createCouponGroupCreateRequest());
+
+        // when
+        var response = request
+                .when().post("/admin/coupon-groups")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+}

--- a/be/promotion/src/test/java/woowa/promotion/admin/admin/application/AdminServiceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/admin/application/AdminServiceTest.java
@@ -1,5 +1,9 @@
 package woowa.promotion.admin.admin.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,15 +17,11 @@ import woowa.promotion.global.exception.ApiException;
 import woowa.promotion.global.security.hash.PasswordEncoder;
 import woowa.promotion.util.ApplicationTest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 @DisplayName("[비즈니스 로직 테스트] 관리자")
-class AuthServiceTest extends ApplicationTest {
+class AdminServiceTest extends ApplicationTest {
 
     @Autowired
-    private AuthService authService;
+    private AdminService adminService;
     @Autowired
     private PasswordEncoder passwordEncoder;
 
@@ -36,7 +36,7 @@ class AuthServiceTest extends ApplicationTest {
             SignupServiceRequest request = FixtureFactory.createSignupServiceRequest();
 
             // when
-            authService.signup(request);
+            adminService.signup(request);
 
             String encrypted = passwordEncoder.encrypt(request.password());
 
@@ -57,7 +57,7 @@ class AuthServiceTest extends ApplicationTest {
             supportRepository.save(FixtureFactory.createAdmin());
 
             // when & then
-            assertThatThrownBy(() -> authService.signup(request))
+            assertThatThrownBy(() -> adminService.signup(request))
                     .isInstanceOf(ApiException.class);
         }
     }
@@ -74,7 +74,7 @@ class AuthServiceTest extends ApplicationTest {
             supportRepository.save(FixtureFactory.createAdmin());
 
             // when
-            SignInServiceResponse response = authService.signIn(request);
+            SignInServiceResponse response = adminService.signIn(request);
 
             // then
             assertThat(response.accessToken()).isNotBlank();
@@ -87,7 +87,7 @@ class AuthServiceTest extends ApplicationTest {
             SignInServiceRequest request = FixtureFactory.createSignInServiceRequest();
 
             // when & then
-            assertThatThrownBy(() -> authService.signIn(request))
+            assertThatThrownBy(() -> adminService.signIn(request))
                     .isInstanceOf(ApiException.class);
         }
     }

--- a/be/promotion/src/test/java/woowa/promotion/admin/documentation/AuthDocumentationTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/documentation/AuthDocumentationTest.java
@@ -1,34 +1,40 @@
 package woowa.promotion.admin.documentation;
 
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import woowa.promotion.admin.admin.application.AuthService;
+import woowa.promotion.admin.admin.application.AdminService;
 import woowa.promotion.admin.admin.application.dto.request.SignInServiceRequest;
 import woowa.promotion.fixture.FixtureFactory;
 import woowa.promotion.util.DocumentationTest;
-
-import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("[RESTDocs] 관리자 인증 API")
 public class AuthDocumentationTest extends DocumentationTest {
 
     @Autowired
-    private AuthService authService;
+    private AdminService adminService;
 
     @DisplayName("관리자 회원가입")
     @Test
     void signup() throws Exception {
         // given
         var signupData = FixtureFactory.createSignupServiceRequest();
-        willDoNothing().given(authService).signup(signupData);
+        willDoNothing().given(adminService).signup(signupData);
 
         // when
         var response = mockMvc.perform(post("/admin/auth/sign-up")
@@ -56,7 +62,7 @@ public class AuthDocumentationTest extends DocumentationTest {
     void signIn() throws Exception {
         // given
         var signInData = FixtureFactory.createSignInRequest();
-        given(authService.signIn(any(SignInServiceRequest.class))).willReturn(FixtureFactory.createSignInServiceResponse());
+        given(adminService.signIn(any(SignInServiceRequest.class))).willReturn(FixtureFactory.createSignInServiceResponse());
 
         // when
         var response = mockMvc.perform(post("/admin/auth/sign-in")

--- a/be/promotion/src/test/java/woowa/promotion/fixture/FixtureFactory.java
+++ b/be/promotion/src/test/java/woowa/promotion/fixture/FixtureFactory.java
@@ -1,11 +1,15 @@
 package woowa.promotion.fixture;
 
+import java.time.Instant;
+import java.util.List;
 import woowa.promotion.admin.admin.application.dto.request.SignInServiceRequest;
 import woowa.promotion.admin.admin.application.dto.request.SignupServiceRequest;
 import woowa.promotion.admin.admin.application.dto.response.SignInServiceResponse;
 import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.admin.admin.presentation.dto.request.SignInRequest;
 import woowa.promotion.admin.admin.presentation.dto.request.SignupRequest;
+import woowa.promotion.admin.coupon_group.presentation.dto.CouponGroupCreateRequest;
+import woowa.promotion.admin.coupon_group.presentation.dto.CouponGroupCreateRequest.CouponDto;
 import woowa.promotion.app.member.domain.Member;
 
 public class FixtureFactory {
@@ -50,5 +54,16 @@ public class FixtureFactory {
 
     public static Admin createAdmin() {
         return Admin.of("브루니", "bruni@woowa.com", "1234");
+    }
+
+    public static CouponGroupCreateRequest createCouponGroupCreateRequest() {
+        return new CouponGroupCreateRequest(
+                "쿠폰 그룹 제목",
+                Instant.parse("2023-10-06T14:30:00Z"),
+                Instant.parse("2023-10-06T14:30:00Z"),
+                List.of(
+                        new CouponDto("쿠폰 제목", "fixed", 1000, 100)
+                )
+        );
     }
 }

--- a/be/promotion/src/test/java/woowa/promotion/util/AcceptanceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/util/AcceptanceTest.java
@@ -12,6 +12,7 @@ import woowa.promotion.acceptance.SupportRepository;
 import woowa.promotion.app.member.domain.Member;
 import woowa.promotion.fixture.FixtureFactory;
 import woowa.promotion.fixture.UserFixture;
+import woowa.promotion.global.domain.jwt.JwtProvider;
 import woowa.promotion.global.security.hash.PasswordEncoder;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -19,12 +20,17 @@ import woowa.promotion.global.security.hash.PasswordEncoder;
 @Sql(value = {"classpath:schema.sql"}, executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
 public abstract class AcceptanceTest {
 
-    @Autowired
-    protected SupportRepository supportRepository;
     @LocalServerPort
     private int port;
+
+    @Autowired
+    protected SupportRepository supportRepository;
+
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    protected JwtProvider jwtProvider;
 
     @BeforeEach
     void setUp() {

--- a/be/promotion/src/test/java/woowa/promotion/util/DocumentationTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/util/DocumentationTest.java
@@ -1,5 +1,8 @@
 package woowa.promotion.util;
 
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,8 +11,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import woowa.promotion.admin.admin.application.AdminService;
+import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.admin.admin.presentation.AuthController;
-import woowa.promotion.global.domain.jwt.JwtProvider;
 import woowa.promotion.global.interceptor.AuthInterceptor;
 import woowa.promotion.global.resolver.AuthArgumentResolver;
 
@@ -24,21 +27,20 @@ public abstract class DocumentationTest {
 
     @Autowired
     protected MockMvc mockMvc;
+
     @Autowired
     protected ObjectMapper objectMapper;
 
     @MockBean
-    protected JwtProvider jwtProvider;
-    @MockBean
     protected AuthInterceptor authInterceptor;
+
     @MockBean
     protected AuthArgumentResolver authArgumentResolver;
 
     @BeforeEach
     void setUp() {
-        given(jwtProvider.createAccessToken(any(Map.class))).willReturn("accessToken");
         given(authInterceptor.preHandle(any(), any(), any())).willReturn(true);
-        given(authArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(1L);
+        given(authArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(Admin.of("nickname", "email", "password"));
     }
-
 }

--- a/be/promotion/src/test/java/woowa/promotion/util/DocumentationTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/util/DocumentationTest.java
@@ -7,19 +7,14 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
-import woowa.promotion.admin.admin.application.AuthService;
+import woowa.promotion.admin.admin.application.AdminService;
 import woowa.promotion.admin.admin.presentation.AuthController;
 import woowa.promotion.global.domain.jwt.JwtProvider;
 import woowa.promotion.global.interceptor.AuthInterceptor;
 import woowa.promotion.global.resolver.AuthArgumentResolver;
 
-import java.util.Map;
-
-import static org.mockito.BDDMockito.any;
-import static org.mockito.BDDMockito.given;
-
 @MockBean({
-        AuthService.class
+        AdminService.class
 })
 @WebMvcTest({
         AuthController.class

--- a/be/promotion/src/test/resources/schema.sql
+++ b/be/promotion/src/test/resources/schema.sql
@@ -9,7 +9,7 @@ DROP TABLE IF EXISTS member;
 CREATE TABLE member
 (
     id         BIGINT       NOT NULL AUTO_INCREMENT,
-    nickname   VARCHAR(45)  NOT NULL,
+    nickname   VARCHAR(45)  NOT NULL UNIQUE,
     email      VARCHAR(45)  NOT NULL,
     created_at TIMESTAMP    NOT NULL,
     password   VARCHAR(500) NOT NULL,
@@ -63,11 +63,12 @@ CREATE TABLE promotion_option
 DROP TABLE IF EXISTS coupon_group;
 CREATE TABLE coupon_group
 (
-    id           BIGINT      NOT NULL AUTO_INCREMENT,
-    title        VARCHAR(50) NOT NULL,
-    started_at   TIMESTAMP   NOT NULL,
-    finished_at  TIMESTAMP   NOT NULL,
-    promotion_id BIGINT      NOT NULL,
+    id             BIGINT      NOT NULL AUTO_INCREMENT,
+    title          VARCHAR(50) NOT NULL,
+    started_at     TIMESTAMP   NOT NULL,
+    finished_at    TIMESTAMP   NOT NULL,
+    admin_nickname VARCHAR(45) NOT NULL,
+    promotion_id   BIGINT      NULL,
     PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
## ✨ Issue
- #24 

## 🔑 Key changes
- [X] 쿠폰 그룹 생성 시, 프로모션이 없을 수도 있어서 null 허용으로 수정
- [X] 쿠폰 생성 시, initial 수량으로 잔여 수량 초기화함
- [X] 쿠폰 그룹 생성자(작성자) 추가
  - [X] 닉네임으로 어드민 정보 조회 요청 기능이 생길 것을 고려해 nickname 컬럼에 unique 제약조건 추가

## 👋 To reviewers
- 테스트 코드 작성할 때나, 인터셉터 혹은 서비스에서 각각 Json Claim Key 값(`memberId`, `adminId`)를 관리하고 있는데
한 곳에서 관리하는 좋은 방법이 있을까요?
- 테스트 코드쪽 디렉토리가 지저분하고 인수테스트 통합테스트 구분이 명확하지 않아서 한번 정리해야 할 것 같습니다.