### PR TITLE
[BE][feat] 프로모션 생성 및 조회 API

### DIFF
--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/domain/CouponGroup.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/domain/CouponGroup.java
@@ -47,4 +47,9 @@ public class CouponGroup {
         this.finishedAt = finishedAt;
         this.adminNickname = adminNickname;
     }
+
+    public void setPromotion(Promotion promotion) {
+        this.promotion = promotion;
+    }
+
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/PromotionService.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/PromotionService.java
@@ -51,9 +51,7 @@ public class PromotionService {
 
         couponGroup.setPromotion(promotion);
 
-        PromotionOptionCouponGroup promotionOptionCouponGroup = new PromotionOptionCouponGroup(promotionOption,
-                couponGroup);
-        promotionOptionCouponGroupRepository.save(promotionOptionCouponGroup);
+        promotionOptionCouponGroupRepository.save(new PromotionOptionCouponGroup(promotionOption, couponGroup));
     }
 
     private PromotionOption savePromotionOption(PromotionOptionRequest promotionOptionRequest, Promotion promotion) {

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/PromotionService.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/PromotionService.java
@@ -1,0 +1,84 @@
+package woowa.promotion.admin.promotion.application;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import woowa.promotion.admin.coupon_group.domain.CouponGroup;
+import woowa.promotion.admin.coupon_group.infrastructure.CouponGroupRepository;
+import woowa.promotion.admin.promotion.application.dto.request.PromotionRegisterRequest;
+import woowa.promotion.admin.promotion.application.dto.request.PromotionRegisterRequest.PromotionOptionRequest;
+import woowa.promotion.admin.promotion.application.dto.response.PromotionDetailResponse;
+import woowa.promotion.admin.promotion.application.dto.response.PromotionListResponse;
+import woowa.promotion.admin.promotion.domain.Promotion;
+import woowa.promotion.admin.promotion.infrastructure.PromotionRepository;
+import woowa.promotion.admin.promotion_option.domain.PromotionOption;
+import woowa.promotion.admin.promotion_option.infrastructure.PromotionOptionRepository;
+import woowa.promotion.admin.promotion_option_coupon_group.domain.PromotionOptionCouponGroup;
+import woowa.promotion.admin.promotion_option_coupon_group.infrastructure.PromotionOptionCouponGroupRepository;
+import woowa.promotion.global.exception.ApiException;
+import woowa.promotion.global.exception.domain.CouponGroupException;
+import woowa.promotion.global.exception.domain.PromotionException;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class PromotionService {
+
+    private final PromotionRepository promotionRepository;
+    private final PromotionOptionRepository promotionOptionRepository;
+    private final CouponGroupRepository couponGroupRepository;
+    private final PromotionOptionCouponGroupRepository promotionOptionCouponGroupRepository;
+
+    @Transactional
+    public void register(PromotionRegisterRequest request) {
+        Promotion promotion = savePromotion(request);
+
+        request.promotionOptions().forEach(promotionOptionRequest ->
+                savePromotionOptionWithCouponGroup(promotionOptionRequest, promotion));
+    }
+
+    private Promotion savePromotion(PromotionRegisterRequest request) {
+        return promotionRepository.save(request.toEntity());
+    }
+
+    private void savePromotionOptionWithCouponGroup(PromotionOptionRequest promotionOptionRequest,
+                                                    Promotion promotion) {
+        CouponGroup couponGroup = couponGroupRepository.findById(promotionOptionRequest.couponGroupId())
+                .orElseThrow(() -> new ApiException(CouponGroupException.NOT_FOUND));
+
+        PromotionOption promotionOption = savePromotionOption(promotionOptionRequest, promotion);
+
+        couponGroup.setPromotion(promotion);
+
+        PromotionOptionCouponGroup promotionOptionCouponGroup = new PromotionOptionCouponGroup(promotionOption,
+                couponGroup);
+        promotionOptionCouponGroupRepository.save(promotionOptionCouponGroup);
+    }
+
+    private PromotionOption savePromotionOption(PromotionOptionRequest promotionOptionRequest, Promotion promotion) {
+        return promotionOptionRepository.save(promotionOptionRequest.toEntity(promotion));
+    }
+
+    public List<PromotionListResponse> getPromotionList() {
+        List<Promotion> promotions = promotionRepository.findAll();
+        return promotions.stream().map(PromotionListResponse::from).toList();
+    }
+
+
+    @Transactional(readOnly = true)
+    public PromotionDetailResponse getPromotion(Long promotionId) {
+        Promotion promotion = promotionRepository.findById(promotionId)
+                .orElseThrow(() -> new ApiException(PromotionException.NOT_FOUND));
+
+        List<PromotionOption> promotionOptions = promotionOptionRepository.findByPromotionId(promotionId);
+
+        List<CouponGroup> couponGroups = promotionOptions.stream()
+                .map(promotionOption -> promotionOptionCouponGroupRepository.findByPromotionOptionId(
+                                promotionOption.getId()).orElseThrow(() -> new ApiException(CouponGroupException.NOT_FOUND))
+                        .getCouponGroup())
+                .toList();
+
+        return new PromotionDetailResponse(promotion, promotionOptions, couponGroups);
+    }
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/PromotionService.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/PromotionService.java
@@ -59,8 +59,10 @@ public class PromotionService {
     }
 
     public List<PromotionListResponse> getPromotionList() {
-        List<Promotion> promotions = promotionRepository.findAll();
-        return promotions.stream().map(PromotionListResponse::from).toList();
+        return promotionRepository.findAll()
+                .stream()
+                .map(PromotionListResponse::from)
+                .toList();
     }
 
 

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/PromotionService.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/PromotionService.java
@@ -66,7 +66,6 @@ public class PromotionService {
     }
 
 
-    @Transactional(readOnly = true)
     public PromotionDetailResponse getPromotion(Long promotionId) {
         Promotion promotion = promotionRepository.findById(promotionId)
                 .orElseThrow(() -> new ApiException(PromotionException.NOT_FOUND));

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/dto/request/PromotionRegisterRequest.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/dto/request/PromotionRegisterRequest.java
@@ -1,5 +1,6 @@
 package woowa.promotion.admin.promotion.application.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.List;
 import woowa.promotion.admin.promotion.domain.ProgressStatus;
@@ -14,6 +15,7 @@ public record PromotionRegisterRequest(
         Instant startedAt,
         Instant finishedAt,
         String promotionPageUrl,
+        @JsonProperty("isDisplay")
         boolean isDisplay,
         String progressStatus,
         List<PromotionOptionRequest> promotionOptions

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/dto/request/PromotionRegisterRequest.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/dto/request/PromotionRegisterRequest.java
@@ -1,0 +1,38 @@
+package woowa.promotion.admin.promotion.application.dto.request;
+
+import java.time.Instant;
+import java.util.List;
+import woowa.promotion.admin.promotion.domain.ProgressStatus;
+import woowa.promotion.admin.promotion.domain.Promotion;
+import woowa.promotion.admin.promotion_option.domain.MemberType;
+import woowa.promotion.admin.promotion_option.domain.PromotionOption;
+
+public record PromotionRegisterRequest(
+        String title,
+        String content,
+        String banner,
+        Instant startedAt,
+        Instant finishedAt,
+        String promotionPageUrl,
+        boolean isDisplay,
+        String progressStatus,
+        List<PromotionOptionRequest> promotionOptions
+) {
+    public Promotion toEntity() {
+        return new Promotion(title, content, banner, startedAt, finishedAt, ProgressStatus.valueOf(progressStatus),
+                promotionPageUrl,
+                isDisplay);
+    }
+
+    public record PromotionOptionRequest(
+            String memberType,
+            Instant lastOrderAt,
+            Boolean isRandom,
+            Long couponGroupId
+    ) {
+        public PromotionOption toEntity(Promotion promotion) {
+            return new PromotionOption(lastOrderAt, isRandom, promotion, MemberType.from(memberType));
+        }
+
+    }
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/dto/response/PromotionDetailResponse.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/dto/response/PromotionDetailResponse.java
@@ -1,0 +1,69 @@
+package woowa.promotion.admin.promotion.application.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import woowa.promotion.admin.coupon_group.domain.CouponGroup;
+import woowa.promotion.admin.promotion.domain.Promotion;
+import woowa.promotion.admin.promotion_option.domain.PromotionOption;
+
+public record PromotionDetailResponse(
+        String title,
+        String content,
+        String bannerUrl,
+        Instant startedAt,
+        Instant finishedAt,
+        boolean isDisplay,
+        String progressStatus,
+        String promotionPageUrl,
+        List<PromotionOptionResponse> promotionOptions
+
+) {
+
+    public record PromotionOptionResponse(
+            String member,
+            Instant lastOrderAt,
+            Boolean isRandom,
+            CouponGroupResponse couponGroup
+    ) {
+        public PromotionOptionResponse(PromotionOption promotionOption, CouponGroup couponGroups) {
+            this(promotionOption.getMemberType().name(), promotionOption.getLastOrderAt(),
+                    promotionOption.getIsRandom(), new CouponGroupResponse(couponGroups));
+        }
+    }
+
+    public record CouponGroupResponse(
+            Long id,
+            String title) {
+        public CouponGroupResponse(CouponGroup couponGroup) {
+            this(couponGroup.getId(), couponGroup.getTitle());
+        }
+    }
+
+    public PromotionDetailResponse(
+            Promotion promotion,
+            List<PromotionOption> promotionOption,
+            List<CouponGroup> couponGroups
+    ) {
+        this(
+                promotion.getTitle(),
+                promotion.getContent(),
+                promotion.getBannerUrl(),
+                promotion.getStartedAt(),
+                promotion.getFinishedAt(),
+                promotion.getIsDisplay(),
+                promotion.getProgressStatus().name(),
+                promotion.getPromotionPageUrl(),
+                makePromotionOptionResponse(promotionOption, couponGroups)
+        );
+    }
+
+    private static List<PromotionOptionResponse> makePromotionOptionResponse(List<PromotionOption> promotionOptions,
+                                                                             List<CouponGroup> couponGroups) {
+        return IntStream.range(0, promotionOptions.size())
+                .mapToObj(index -> new PromotionOptionResponse(promotionOptions.get(index), couponGroups.get(index)))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/dto/response/PromotionListResponse.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/application/dto/response/PromotionListResponse.java
@@ -1,0 +1,22 @@
+package woowa.promotion.admin.promotion.application.dto.response;
+
+import java.time.Instant;
+import woowa.promotion.admin.promotion.domain.Promotion;
+
+public record PromotionListResponse(
+        Long id,
+        String bannerUrl,
+        String title,
+        Instant startedAt,
+        Instant finishedAt,
+        String progressStatus
+) {
+    public static PromotionListResponse from(Promotion promotion) {
+        return new PromotionListResponse(promotion.getId(),
+                promotion.getBannerUrl(),
+                promotion.getTitle(),
+                promotion.getStartedAt(),
+                promotion.getFinishedAt(),
+                promotion.getProgressStatus().name());
+    }
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/domain/Promotion.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/domain/Promotion.java
@@ -59,8 +59,5 @@ public class Promotion extends AuditingFields {
         this.isDisplay = isDisplay;
     }
 
-    public void setId(String title) {
-        this.title = title;
-    }
 
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/domain/Promotion.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/domain/Promotion.java
@@ -11,7 +11,6 @@ import javax.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
 import woowa.promotion.global.domain.audit.AuditingFields;
 
 @Getter
@@ -33,7 +32,6 @@ public class Promotion extends AuditingFields {
     private String bannerUrl;
 
     @Column(nullable = false, updatable = false)
-    @CreatedDate
     private Instant startedAt;
 
     @Column(nullable = false)
@@ -48,5 +46,21 @@ public class Promotion extends AuditingFields {
 
     @Column(nullable = false, columnDefinition = "TINYINT")
     private Boolean isDisplay;
+
+    public Promotion(String title, String content, String bannerUrl, Instant startedAt, Instant finishedAt,
+                     ProgressStatus progressStatus, String promotionPageUrl, Boolean isDisplay) {
+        this.title = title;
+        this.content = content;
+        this.bannerUrl = bannerUrl;
+        this.startedAt = startedAt;
+        this.finishedAt = finishedAt;
+        this.progressStatus = progressStatus;
+        this.promotionPageUrl = promotionPageUrl;
+        this.isDisplay = isDisplay;
+    }
+
+    public void setId(String title) {
+        this.title = title;
+    }
 
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/infrastructure/PromotionRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/infrastructure/PromotionRepository.java
@@ -1,0 +1,7 @@
+package woowa.promotion.admin.promotion.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import woowa.promotion.admin.promotion.domain.Promotion;
+
+public interface PromotionRepository extends JpaRepository<Promotion, Long> {
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/presentation/PromotionController.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/presentation/PromotionController.java
@@ -16,13 +16,13 @@ import woowa.promotion.admin.promotion.application.dto.response.PromotionDetailR
 import woowa.promotion.admin.promotion.application.dto.response.PromotionListResponse;
 
 @RequiredArgsConstructor
-@RequestMapping("/admin")
+@RequestMapping("/admin/promotions")
 @RestController
 public class PromotionController {
 
     private final PromotionService promotionService;
 
-    @PostMapping("/promotions")
+    @PostMapping("")
     public ResponseEntity<Void> register(
             @RequestBody PromotionRegisterRequest request
     ) {
@@ -30,13 +30,13 @@ public class PromotionController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @GetMapping("/promotions")
+    @GetMapping("")
     public ResponseEntity<List<PromotionListResponse>> getPromotionList() {
         var response = promotionService.getPromotionList();
         return ResponseEntity.ok().body(response);
     }
 
-    @GetMapping("/promotions{promotionId}")
+    @GetMapping("/{promotionId}")
     public ResponseEntity<PromotionDetailResponse> getPromotion(
             @PathVariable Long promotionId
     ) {

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/presentation/PromotionController.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/presentation/PromotionController.java
@@ -1,0 +1,46 @@
+package woowa.promotion.admin.promotion.presentation;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import woowa.promotion.admin.promotion.application.PromotionService;
+import woowa.promotion.admin.promotion.application.dto.request.PromotionRegisterRequest;
+import woowa.promotion.admin.promotion.application.dto.response.PromotionDetailResponse;
+import woowa.promotion.admin.promotion.application.dto.response.PromotionListResponse;
+
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+@RestController
+public class PromotionController {
+
+    private final PromotionService promotionService;
+
+    @PostMapping("/promotions")
+    public ResponseEntity<Void> register(
+            @RequestBody PromotionRegisterRequest request
+    ) {
+        promotionService.register(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/promotions")
+    public ResponseEntity<List<PromotionListResponse>> getPromotionList() {
+        var response = promotionService.getPromotionList();
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/promotions{promotionId}")
+    public ResponseEntity<PromotionDetailResponse> getPromotion(
+            @PathVariable Long promotionId
+    ) {
+        var response = promotionService.getPromotion(promotionId);
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion_option/domain/MemberType.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion_option/domain/MemberType.java
@@ -1,7 +1,18 @@
 package woowa.promotion.admin.promotion_option.domain;
 
+import java.util.Arrays;
+import woowa.promotion.global.exception.ApiException;
+import woowa.promotion.global.exception.domain.MemberTypeException;
+
 public enum MemberType {
 
-    NEW_MEMBER, OLD_MEMBER
+    NEW_MEMBER, OLD_MEMBER;
+
+    public static MemberType from(String type) {
+        return Arrays.stream(MemberType.values())
+                .filter(couponType -> couponType.name().equalsIgnoreCase(type))
+                .findAny()
+                .orElseThrow(() -> new ApiException(MemberTypeException.INVALID_MEMBER_TYPE));
+    }
 
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion_option/domain/PromotionOption.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion_option/domain/PromotionOption.java
@@ -3,6 +3,8 @@ package woowa.promotion.admin.promotion_option.domain;
 import java.time.Instant;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -32,4 +34,14 @@ public class PromotionOption {
     @ManyToOne(fetch = FetchType.LAZY)
     private Promotion promotion;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MemberType memberType;
+
+    public PromotionOption(Instant lastOrderAt, Boolean isRandom, Promotion promotion, MemberType memberType) {
+        this.lastOrderAt = lastOrderAt;
+        this.isRandom = isRandom;
+        this.promotion = promotion;
+        this.memberType = memberType;
+    }
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion_option/infrastructure/PromotionOptionRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion_option/infrastructure/PromotionOptionRepository.java
@@ -1,0 +1,9 @@
+package woowa.promotion.admin.promotion_option.infrastructure;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import woowa.promotion.admin.promotion_option.domain.PromotionOption;
+
+public interface PromotionOptionRepository extends JpaRepository<PromotionOption, Long> {
+    List<PromotionOption> findByPromotionId(Long id);
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion_option/infrastructure/PromotionOptionRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion_option/infrastructure/PromotionOptionRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import woowa.promotion.admin.promotion_option.domain.PromotionOption;
 
 public interface PromotionOptionRepository extends JpaRepository<PromotionOption, Long> {
+    
     List<PromotionOption> findByPromotionId(Long id);
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion_option_coupon_group/domain/PromotionOptionCouponGroup.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion_option_coupon_group/domain/PromotionOptionCouponGroup.java
@@ -1,4 +1,4 @@
-package woowa.promotion.admin.promotion_option_coupon.domain;
+package woowa.promotion.admin.promotion_option_coupon_group.domain;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -10,13 +10,13 @@ import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import woowa.promotion.admin.coupon.domain.Coupon;
+import woowa.promotion.admin.coupon_group.domain.CouponGroup;
 import woowa.promotion.admin.promotion_option.domain.PromotionOption;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class PromotionOptionCoupon {
+public class PromotionOptionCouponGroup {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,8 +26,12 @@ public class PromotionOptionCoupon {
     @ManyToOne(fetch = FetchType.LAZY)
     private PromotionOption promotionOption;
 
-    @JoinColumn(name = "coupon_id", nullable = false)
+    @JoinColumn(name = "coupon_group_id", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
-    private Coupon coupon;
+    private CouponGroup couponGroup;
 
+    public PromotionOptionCouponGroup(PromotionOption promotionOption, CouponGroup couponGroup) {
+        this.promotionOption = promotionOption;
+        this.couponGroup = couponGroup;
+    }
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion_option_coupon_group/infrastructure/PromotionOptionCouponGroupRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion_option_coupon_group/infrastructure/PromotionOptionCouponGroupRepository.java
@@ -1,10 +1,10 @@
 package woowa.promotion.admin.promotion_option_coupon_group.infrastructure;
 
-import java.util.Optional;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import woowa.promotion.admin.promotion_option_coupon_group.domain.PromotionOptionCouponGroup;
 
 public interface PromotionOptionCouponGroupRepository extends JpaRepository<PromotionOptionCouponGroup, Long> {
-    
-    Optional<PromotionOptionCouponGroup> findByPromotionOptionId(Long id);
+
+    List<PromotionOptionCouponGroup> findByPromotionOptionId(Long id);
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion_option_coupon_group/infrastructure/PromotionOptionCouponGroupRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion_option_coupon_group/infrastructure/PromotionOptionCouponGroupRepository.java
@@ -1,0 +1,9 @@
+package woowa.promotion.admin.promotion_option_coupon_group.infrastructure;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import woowa.promotion.admin.promotion_option_coupon_group.domain.PromotionOptionCouponGroup;
+
+public interface PromotionOptionCouponGroupRepository extends JpaRepository<PromotionOptionCouponGroup, Long> {
+    Optional<PromotionOptionCouponGroup> findByPromotionOptionId(Long id);
+}

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion_option_coupon_group/infrastructure/PromotionOptionCouponGroupRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion_option_coupon_group/infrastructure/PromotionOptionCouponGroupRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import woowa.promotion.admin.promotion_option_coupon_group.domain.PromotionOptionCouponGroup;
 
 public interface PromotionOptionCouponGroupRepository extends JpaRepository<PromotionOptionCouponGroup, Long> {
+    
     Optional<PromotionOptionCouponGroup> findByPromotionOptionId(Long id);
 }

--- a/be/promotion/src/main/java/woowa/promotion/global/exception/domain/CouponGroupException.java
+++ b/be/promotion/src/main/java/woowa/promotion/global/exception/domain/CouponGroupException.java
@@ -1,0 +1,16 @@
+package woowa.promotion.global.exception.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import woowa.promotion.global.exception.CustomException;
+
+@Getter
+@RequiredArgsConstructor
+public enum CouponGroupException implements CustomException {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 쿠폰 그룹 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/be/promotion/src/main/java/woowa/promotion/global/exception/domain/MemberTypeException.java
+++ b/be/promotion/src/main/java/woowa/promotion/global/exception/domain/MemberTypeException.java
@@ -1,0 +1,15 @@
+package woowa.promotion.global.exception.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import woowa.promotion.global.exception.CustomException;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberTypeException implements CustomException {
+    INVALID_MEMBER_TYPE(HttpStatus.BAD_REQUEST, "잘못된 멤버 타입입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/be/promotion/src/main/java/woowa/promotion/global/exception/domain/PromotionException.java
+++ b/be/promotion/src/main/java/woowa/promotion/global/exception/domain/PromotionException.java
@@ -1,0 +1,16 @@
+package woowa.promotion.global.exception.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import woowa.promotion.global.exception.CustomException;
+
+@Getter
+@RequiredArgsConstructor
+public enum PromotionException implements CustomException {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 프로모션 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/be/promotion/src/main/java/woowa/promotion/global/exception/domain/PromotionOptionException.java
+++ b/be/promotion/src/main/java/woowa/promotion/global/exception/domain/PromotionOptionException.java
@@ -8,6 +8,7 @@ import woowa.promotion.global.exception.CustomException;
 @Getter
 @RequiredArgsConstructor
 public enum PromotionOptionException implements CustomException {
+    
     NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 프로모션 옵션 입니다.");
 
     private final HttpStatus httpStatus;

--- a/be/promotion/src/main/java/woowa/promotion/global/exception/domain/PromotionOptionException.java
+++ b/be/promotion/src/main/java/woowa/promotion/global/exception/domain/PromotionOptionException.java
@@ -1,0 +1,15 @@
+package woowa.promotion.global.exception.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import woowa.promotion.global.exception.CustomException;
+
+@Getter
+@RequiredArgsConstructor
+public enum PromotionOptionException implements CustomException {
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 프로모션 옵션 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/be/promotion/src/main/resources/schema.sql
+++ b/be/promotion/src/main/resources/schema.sql
@@ -59,11 +59,11 @@ CREATE TABLE IF NOT EXISTS coupon_group
     PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS promotion_option_coupon
+CREATE TABLE IF NOT EXISTS promotion_option_coupon_group
 (
     id                  BIGINT NOT NULL AUTO_INCREMENT,
     promotion_option_id BIGINT NOT NULL,
-    coupon_id           BIGINT NOT NULL,
+    coupon_group_id           BIGINT NOT NULL,
     PRIMARY KEY (id)
 );
 

--- a/be/promotion/src/test/java/woowa/promotion/acceptance/PromotionAcceptanceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/acceptance/PromotionAcceptanceTest.java
@@ -1,0 +1,81 @@
+package woowa.promotion.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static woowa.promotion.fixture.CouponGroupFixture.A_쿠폰그룹;
+import static woowa.promotion.fixture.CouponGroupFixture.B_쿠폰그룹;
+import static woowa.promotion.fixture.FixtureFactory.createCouponGroup;
+import static woowa.promotion.fixture.FixtureFactory.createPromotion;
+import static woowa.promotion.fixture.FixtureFactory.createPromotionOptionRequest;
+import static woowa.promotion.fixture.PromotionFixture.A_프로모션;
+import static woowa.promotion.fixture.PromotionFixture.B_프로모션;
+import static woowa.promotion.fixture.PromotionOptionFixture.A_프로모션_옵션;
+import static woowa.promotion.fixture.PromotionOptionFixture.B_프로모션_옵션;
+
+import io.restassured.RestAssured;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import woowa.promotion.admin.admin.domain.Admin;
+import woowa.promotion.admin.coupon_group.domain.CouponGroup;
+import woowa.promotion.admin.promotion.application.dto.request.PromotionRegisterRequest.PromotionOptionRequest;
+import woowa.promotion.fixture.FixtureFactory;
+import woowa.promotion.util.AcceptanceTest;
+
+public class PromotionAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void register() {
+        // given
+        Admin admin = supportRepository.save(Admin.of("nickname", "email", "password"));
+        String accessToken = jwtProvider.createAccessToken(Map.of("adminId", admin.getId()));
+
+        CouponGroup couponGroupA = makeCouponGroup(createCouponGroup(A_쿠폰그룹));
+        CouponGroup couponGroupB = makeCouponGroup(createCouponGroup(B_쿠폰그룹));
+        PromotionOptionRequest promotionOptionRequestA = createPromotionOptionRequest(A_프로모션_옵션, couponGroupA.getId());
+        PromotionOptionRequest promotionOptionRequestB = createPromotionOptionRequest(B_프로모션_옵션, couponGroupB.getId());
+
+        var request = RestAssured
+                .given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(FixtureFactory.createPromotionRegisterRequest(A_프로모션,
+                        List.of(promotionOptionRequestA, promotionOptionRequestB)));
+
+        // when
+        var response = request
+                .when().post("/admin/promotions")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void getPromotionList() {
+        // given
+        Admin admin = supportRepository.save(Admin.of("nickname", "email", "password"));
+        String accessToken = jwtProvider.createAccessToken(Map.of("adminId", admin.getId()));
+
+        var promotionA = makePromotion(createPromotion(A_프로모션));
+        var promotionB = makePromotion(createPromotion(B_프로모션));
+        var request = RestAssured
+                .given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE);
+
+        // when
+        var response = request
+                .when().get("/admin/promotions")
+                .then().log().all()
+                .extract();
+
+        // then
+        System.out.println("result+ " + response.body().jsonPath());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.body().jsonPath().getString("contents[0].title"));
+    }
+
+}

--- a/be/promotion/src/test/java/woowa/promotion/acceptance/PromotionAcceptanceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/acceptance/PromotionAcceptanceTest.java
@@ -73,7 +73,6 @@ public class PromotionAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         // then
-        System.out.println("result+ " + response.body().jsonPath());
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.body().jsonPath().getString("contents[0].title"));
     }

--- a/be/promotion/src/test/java/woowa/promotion/acceptance/PromotionAcceptanceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/acceptance/PromotionAcceptanceTest.java
@@ -14,6 +14,7 @@ import static woowa.promotion.fixture.PromotionOptionFixture.B_프로모션_옵�
 import io.restassured.RestAssured;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -23,8 +24,10 @@ import woowa.promotion.admin.promotion.application.dto.request.PromotionRegister
 import woowa.promotion.fixture.FixtureFactory;
 import woowa.promotion.util.AcceptanceTest;
 
+@DisplayName("[인수테스트] 관리자 - 프로모션")
 public class PromotionAcceptanceTest extends AcceptanceTest {
 
+    @DisplayName("프로모션 등록에 성공한다.")
     @Test
     void register() {
         // given
@@ -53,6 +56,7 @@ public class PromotionAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
 
+    @DisplayName("프로모션 리스트를 조회한다.")
     @Test
     void getPromotionList() {
         // given

--- a/be/promotion/src/test/java/woowa/promotion/admin/promotion/application/PromotionServiceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/promotion/application/PromotionServiceTest.java
@@ -14,6 +14,7 @@ import static woowa.promotion.fixture.PromotionOptionFixture.A_프로모션_옵�
 import static woowa.promotion.fixture.PromotionOptionFixture.B_프로모션_옵션;
 
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import woowa.promotion.admin.coupon_group.domain.CouponGroup;
@@ -28,6 +29,8 @@ import woowa.promotion.admin.promotion_option_coupon_group.domain.PromotionOptio
 import woowa.promotion.admin.promotion_option_coupon_group.infrastructure.PromotionOptionCouponGroupRepository;
 import woowa.promotion.util.ApplicationTest;
 
+
+@DisplayName("[비즈니스 로직 테스트] 관리자 프로모션")
 class PromotionServiceTest extends ApplicationTest {
 
     @Autowired
@@ -42,6 +45,7 @@ class PromotionServiceTest extends ApplicationTest {
     private PromotionOptionCouponGroupRepository promotionOptionCouponGroupRepository;
 
 
+    @DisplayName("프로모션 등록")
     @Test
     void register() {
         // given
@@ -65,6 +69,7 @@ class PromotionServiceTest extends ApplicationTest {
         return couponGroupRepository.save(couponGroup);
     }
 
+    @DisplayName("프로모션 리스트 조회")
     @Test
     void getPromotionList() {
         // given
@@ -72,7 +77,7 @@ class PromotionServiceTest extends ApplicationTest {
         var promotionB = createPromotion(B_프로모션);
         var promotions = List.of(promotionA, promotionB);
         promotionRepository.saveAll(promotions);
-        
+
         // when
         var response = promotionService.getPromotionList();
 
@@ -83,6 +88,7 @@ class PromotionServiceTest extends ApplicationTest {
                 );
     }
 
+    @DisplayName("프로모션 상세 조회")
     @Test
     void getPromotion() {
         // given

--- a/be/promotion/src/test/java/woowa/promotion/admin/promotion/application/PromotionServiceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/promotion/application/PromotionServiceTest.java
@@ -32,7 +32,6 @@ class PromotionServiceTest extends ApplicationTest {
 
     @Autowired
     private PromotionService promotionService;
-
     @Autowired
     private PromotionRepository promotionRepository;
     @Autowired
@@ -60,7 +59,6 @@ class PromotionServiceTest extends ApplicationTest {
         Promotion promotion = promotionRepository.findAll().get(0);
         assertThat(promotion).usingRecursiveComparison().ignoringFields("id", "createdAt")
                 .isEqualTo(request.toEntity());
-
     }
 
     private CouponGroup makeCouponGroup(CouponGroup couponGroup) {
@@ -74,6 +72,7 @@ class PromotionServiceTest extends ApplicationTest {
         var promotionB = createPromotion(B_프로모션);
         var promotions = List.of(promotionA, promotionB);
         promotionRepository.saveAll(promotions);
+        
         // when
         var response = promotionService.getPromotionList();
 
@@ -82,7 +81,6 @@ class PromotionServiceTest extends ApplicationTest {
                 .isEqualTo(promotions.stream().map(
                         PromotionListResponse::from).toList()
                 );
-
     }
 
     @Test

--- a/be/promotion/src/test/java/woowa/promotion/admin/promotion/application/PromotionServiceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/promotion/application/PromotionServiceTest.java
@@ -1,0 +1,127 @@
+package woowa.promotion.admin.promotion.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static woowa.promotion.fixture.CouponGroupFixture.A_쿠폰그룹;
+import static woowa.promotion.fixture.CouponGroupFixture.B_쿠폰그룹;
+import static woowa.promotion.fixture.FixtureFactory.createCouponGroup;
+import static woowa.promotion.fixture.FixtureFactory.createPromotion;
+import static woowa.promotion.fixture.FixtureFactory.createPromotionOption;
+import static woowa.promotion.fixture.FixtureFactory.createPromotionOptionRequest;
+import static woowa.promotion.fixture.FixtureFactory.createPromotionRegisterRequest;
+import static woowa.promotion.fixture.PromotionFixture.A_프로모션;
+import static woowa.promotion.fixture.PromotionFixture.B_프로모션;
+import static woowa.promotion.fixture.PromotionOptionFixture.A_프로모션_옵션;
+import static woowa.promotion.fixture.PromotionOptionFixture.B_프로모션_옵션;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import woowa.promotion.admin.coupon_group.domain.CouponGroup;
+import woowa.promotion.admin.coupon_group.infrastructure.CouponGroupRepository;
+import woowa.promotion.admin.promotion.application.dto.request.PromotionRegisterRequest.PromotionOptionRequest;
+import woowa.promotion.admin.promotion.application.dto.response.PromotionListResponse;
+import woowa.promotion.admin.promotion.domain.Promotion;
+import woowa.promotion.admin.promotion.infrastructure.PromotionRepository;
+import woowa.promotion.admin.promotion_option.domain.PromotionOption;
+import woowa.promotion.admin.promotion_option.infrastructure.PromotionOptionRepository;
+import woowa.promotion.admin.promotion_option_coupon_group.domain.PromotionOptionCouponGroup;
+import woowa.promotion.admin.promotion_option_coupon_group.infrastructure.PromotionOptionCouponGroupRepository;
+import woowa.promotion.util.ApplicationTest;
+
+class PromotionServiceTest extends ApplicationTest {
+
+    @Autowired
+    private PromotionService promotionService;
+
+    @Autowired
+    private PromotionRepository promotionRepository;
+    @Autowired
+    private CouponGroupRepository couponGroupRepository;
+    @Autowired
+    private PromotionOptionRepository promotionOptionRepository;
+    @Autowired
+    private PromotionOptionCouponGroupRepository promotionOptionCouponGroupRepository;
+
+
+    @Test
+    void register() {
+        // given
+        CouponGroup couponGroupA = makeCouponGroup(createCouponGroup(A_쿠폰그룹));
+        CouponGroup couponGroupB = makeCouponGroup(createCouponGroup(B_쿠폰그룹));
+        PromotionOptionRequest promotionOptionRequestA = createPromotionOptionRequest(A_프로모션_옵션, couponGroupA.getId());
+        PromotionOptionRequest promotionOptionRequestB = createPromotionOptionRequest(B_프로모션_옵션, couponGroupB.getId());
+
+        var request = createPromotionRegisterRequest(A_프로모션, List.of(promotionOptionRequestA, promotionOptionRequestB));
+
+        // when
+        promotionService.register(request);
+
+        // then
+        Promotion promotion = promotionRepository.findAll().get(0);
+        assertThat(promotion).usingRecursiveComparison().ignoringFields("id", "createdAt")
+                .isEqualTo(request.toEntity());
+
+    }
+
+    private CouponGroup makeCouponGroup(CouponGroup couponGroup) {
+        return couponGroupRepository.save(couponGroup);
+    }
+
+    @Test
+    void getPromotionList() {
+        // given
+        var promotionA = createPromotion(A_프로모션);
+        var promotionB = createPromotion(B_프로모션);
+        var promotions = List.of(promotionA, promotionB);
+        promotionRepository.saveAll(promotions);
+        // when
+        var response = promotionService.getPromotionList();
+
+        // then
+        assertThat(response).usingRecursiveComparison().ignoringCollectionOrder()
+                .isEqualTo(promotions.stream().map(
+                        PromotionListResponse::from).toList()
+                );
+
+    }
+
+    @Test
+    void getPromotion() {
+        // given
+        Promotion promotionA = makePromotion(createPromotion(A_프로모션));
+        makePromotionAndPromotionOptionAndCouponGroup(promotionA);
+
+        // when
+        var response = promotionService.getPromotion(promotionA.getId());
+
+        // then
+        assertThat(response).usingRecursiveComparison().ignoringFields("promotionOptions").isEqualTo(response);
+    }
+
+    private void makePromotionAndPromotionOptionAndCouponGroup(Promotion promotionA) {
+        CouponGroup couponGroupA = makeCouponGroup(createCouponGroup(A_쿠폰그룹));
+        CouponGroup couponGroupB = makeCouponGroup(createCouponGroup(B_쿠폰그룹));
+        couponGroupA.setPromotion(promotionA);
+        couponGroupB.setPromotion(promotionA);
+        PromotionOption promotionOptionA = makePromotionOption(createPromotionOption(A_프로모션_옵션, promotionA));
+        PromotionOption promotionOptionB = makePromotionOption(createPromotionOption(B_프로모션_옵션, promotionA));
+        makePromotionOptionCouponGroup(promotionOptionA, couponGroupA);
+        makePromotionOptionCouponGroup(promotionOptionB, couponGroupA);
+    }
+
+    private PromotionOptionCouponGroup makePromotionOptionCouponGroup(PromotionOption promotionOption,
+                                                                      CouponGroup couponGroup) {
+        PromotionOptionCouponGroup promotionOptionCouponGroup = new PromotionOptionCouponGroup(promotionOption,
+                couponGroup);
+        return promotionOptionCouponGroupRepository.save(promotionOptionCouponGroup);
+    }
+
+    private Promotion makePromotion(Promotion promotion) {
+        return promotionRepository.save(promotion);
+    }
+
+    private PromotionOption makePromotionOption(PromotionOption promotionOption) {
+        return promotionOptionRepository.save(promotionOption);
+    }
+
+}

--- a/be/promotion/src/test/java/woowa/promotion/fixture/CouponGroupFixture.java
+++ b/be/promotion/src/test/java/woowa/promotion/fixture/CouponGroupFixture.java
@@ -1,0 +1,31 @@
+package woowa.promotion.fixture;
+
+import java.time.Instant;
+
+public enum CouponGroupFixture {
+
+    A_쿠폰그룹("A_쿠폰그룹", Instant.now(), Instant.now()),
+    B_쿠폰그룹("B_쿠폰그룹", Instant.now(), Instant.now());
+
+    private final String title;
+    private final Instant startedAt;
+    private final Instant finishedAt;
+
+    CouponGroupFixture(String title, Instant startedAt, Instant finishedAt) {
+        this.title = title;
+        this.startedAt = startedAt;
+        this.finishedAt = finishedAt;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Instant getStartedAt() {
+        return startedAt;
+    }
+
+    public Instant getFinishedAt() {
+        return finishedAt;
+    }
+}

--- a/be/promotion/src/test/java/woowa/promotion/fixture/FixtureFactory.java
+++ b/be/promotion/src/test/java/woowa/promotion/fixture/FixtureFactory.java
@@ -8,14 +8,28 @@ import woowa.promotion.admin.admin.application.dto.response.SignInServiceRespons
 import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.admin.admin.presentation.dto.request.SignInRequest;
 import woowa.promotion.admin.admin.presentation.dto.request.SignupRequest;
+import woowa.promotion.admin.coupon_group.domain.CouponGroup;
 import woowa.promotion.admin.coupon_group.presentation.dto.CouponGroupCreateRequest;
 import woowa.promotion.admin.coupon_group.presentation.dto.CouponGroupCreateRequest.CouponDto;
+import woowa.promotion.admin.promotion.application.dto.request.PromotionRegisterRequest;
+import woowa.promotion.admin.promotion.application.dto.request.PromotionRegisterRequest.PromotionOptionRequest;
+import woowa.promotion.admin.promotion.domain.ProgressStatus;
+import woowa.promotion.admin.promotion.domain.Promotion;
+import woowa.promotion.admin.promotion_option.domain.MemberType;
+import woowa.promotion.admin.promotion_option.domain.PromotionOption;
 import woowa.promotion.app.member.domain.Member;
 
 public class FixtureFactory {
 
     public static Member createMember(UserFixture userFixture, String password) {
         return new Member(userFixture.getNickname(), userFixture.getEmail(), password);
+    }
+
+    public static PromotionOption createPromotionOption(PromotionOptionFixture promotionOptionFixture,
+                                                        Promotion promotion) {
+        return new PromotionOption(promotionOptionFixture.getLastOrderAt(), promotionOptionFixture.getRandom(),
+                promotion,
+                MemberType.from(promotionOptionFixture.getMemberType()));
     }
 
     public static SignupRequest createSignupRequest() {
@@ -55,6 +69,40 @@ public class FixtureFactory {
     public static Admin createAdmin() {
         return Admin.of("브루니", "bruni@woowa.com", "1234");
     }
+
+    public static Promotion createPromotion(PromotionFixture promotionFixture) {
+        return new Promotion(promotionFixture.getTitle(), promotionFixture.getContent(), promotionFixture.getBanner(),
+                promotionFixture.getStartedAt(), promotionFixture.getFinishedAt(),
+                ProgressStatus.valueOf(promotionFixture.getProgressStatus()), promotionFixture.getPromotionPageUrl(),
+                promotionFixture.isDisplay());
+    }
+
+    public static CouponGroup createCouponGroup(CouponGroupFixture couponGroupFixture) {
+        return CouponGroup.builder().title(couponGroupFixture.getTitle()).finishedAt(couponGroupFixture.getFinishedAt())
+                .startedAt(couponGroupFixture.getStartedAt()).adminNickname("admin").build();
+    }
+
+    public static PromotionOptionRequest createPromotionOptionRequest(PromotionOptionFixture promotionOptionFixture,
+                                                                      Long couponGroupId) {
+        return new PromotionOptionRequest(promotionOptionFixture.getMemberType(),
+                promotionOptionFixture.getLastOrderAt(), promotionOptionFixture.getRandom(), couponGroupId);
+    }
+
+
+    public static PromotionRegisterRequest createPromotionRegisterRequest(PromotionFixture promotionFixture,
+                                                                          List<PromotionOptionRequest> promotionOptions) {
+        return new PromotionRegisterRequest(
+                promotionFixture.getTitle(),
+                promotionFixture.getContent(),
+                promotionFixture.getBanner(),
+                promotionFixture.getStartedAt(),
+                promotionFixture.getFinishedAt(),
+                promotionFixture.getPromotionPageUrl(),
+                promotionFixture.isDisplay(),
+                promotionFixture.getProgressStatus(),
+                promotionOptions);
+    }
+
 
     public static CouponGroupCreateRequest createCouponGroupCreateRequest() {
         return new CouponGroupCreateRequest(

--- a/be/promotion/src/test/java/woowa/promotion/fixture/PromotionFixture.java
+++ b/be/promotion/src/test/java/woowa/promotion/fixture/PromotionFixture.java
@@ -1,0 +1,66 @@
+package woowa.promotion.fixture;
+
+import java.time.Instant;
+import woowa.promotion.admin.promotion.domain.ProgressStatus;
+
+public enum PromotionFixture {
+
+    A_프로모션("누구나 최대 1만원", "먹고 싶은 음식을 고르세요", "www.bannerUrl.com", Instant.now(), Instant.now(),
+            "www.promotionUrl.com", true, ProgressStatus.ON_GOING.name()),
+    B_프로모션("나만 10만원", "먹기 싫은"
+            + " 음식을 고르세요", "www.bannerUrl.com", Instant.now(), Instant.now(),
+            "www.promotionUrl.com", true, ProgressStatus.ON_GOING.name());
+
+    private final String title;
+    private final String content;
+    private final String banner;
+    private final Instant startedAt;
+    private final Instant finishedAt;
+    private final String promotionPageUrl;
+    private final boolean isDisplay;
+    private final String progressStatus;
+
+    PromotionFixture(String title, String content, String banner, Instant startedAt, Instant finishedAt,
+                     String promotionPageUrl, boolean isDisplay, String progressStatus) {
+        this.title = title;
+        this.content = content;
+        this.banner = banner;
+        this.startedAt = startedAt;
+        this.finishedAt = finishedAt;
+        this.promotionPageUrl = promotionPageUrl;
+        this.isDisplay = isDisplay;
+        this.progressStatus = progressStatus;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getBanner() {
+        return banner;
+    }
+
+    public Instant getStartedAt() {
+        return startedAt;
+    }
+
+    public Instant getFinishedAt() {
+        return finishedAt;
+    }
+
+    public String getPromotionPageUrl() {
+        return promotionPageUrl;
+    }
+
+    public boolean isDisplay() {
+        return isDisplay;
+    }
+
+    public String getProgressStatus() {
+        return progressStatus;
+    }
+}

--- a/be/promotion/src/test/java/woowa/promotion/fixture/PromotionOptionFixture.java
+++ b/be/promotion/src/test/java/woowa/promotion/fixture/PromotionOptionFixture.java
@@ -3,8 +3,10 @@ package woowa.promotion.fixture;
 import java.time.Instant;
 
 public enum PromotionOptionFixture {
+
     A_프로모션_옵션(Instant.now(), true, "NEW_MEMBER"),
     B_프로모션_옵션(Instant.now(), false, "OLD_MEMBER");
+    
     private Instant lastOrderAt;
 
     private Boolean isRandom;

--- a/be/promotion/src/test/java/woowa/promotion/fixture/PromotionOptionFixture.java
+++ b/be/promotion/src/test/java/woowa/promotion/fixture/PromotionOptionFixture.java
@@ -1,0 +1,31 @@
+package woowa.promotion.fixture;
+
+import java.time.Instant;
+
+public enum PromotionOptionFixture {
+    A_프로모션_옵션(Instant.now(), true, "NEW_MEMBER"),
+    B_프로모션_옵션(Instant.now(), false, "OLD_MEMBER");
+    private Instant lastOrderAt;
+
+    private Boolean isRandom;
+    private String memberType;
+
+
+    PromotionOptionFixture(Instant lastOrderAt, Boolean isRandom, String memberType) {
+        this.lastOrderAt = lastOrderAt;
+        this.isRandom = isRandom;
+        this.memberType = memberType;
+    }
+
+    public Instant getLastOrderAt() {
+        return lastOrderAt;
+    }
+
+    public Boolean getRandom() {
+        return isRandom;
+    }
+
+    public String getMemberType() {
+        return memberType;
+    }
+}

--- a/be/promotion/src/test/java/woowa/promotion/util/AcceptanceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/util/AcceptanceTest.java
@@ -9,6 +9,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 import woowa.promotion.acceptance.SupportRepository;
+import woowa.promotion.admin.coupon_group.domain.CouponGroup;
+import woowa.promotion.admin.promotion.domain.Promotion;
 import woowa.promotion.app.member.domain.Member;
 import woowa.promotion.fixture.FixtureFactory;
 import woowa.promotion.fixture.UserFixture;
@@ -40,6 +42,14 @@ public abstract class AcceptanceTest {
     protected Member makeMember(UserFixture userFixture) {
         String password = passwordEncoder.encrypt(userFixture.getPassword());
         return supportRepository.save(FixtureFactory.createMember(userFixture, password));
+    }
+
+    protected Promotion makePromotion(Promotion promotion) {
+        return supportRepository.save(promotion);
+    }
+
+    protected CouponGroup makeCouponGroup(CouponGroup couponGroup) {
+        return supportRepository.save(couponGroup);
     }
 }
 

--- a/be/promotion/src/test/resources/schema.sql
+++ b/be/promotion/src/test/resources/schema.sql
@@ -72,12 +72,12 @@ CREATE TABLE coupon_group
     PRIMARY KEY (id)
 );
 
-DROP TABLE IF EXISTS promotion_option_coupon;
-CREATE TABLE promotion_option_coupon
+DROP TABLE IF EXISTS promotion_option_coupon_group;
+CREATE TABLE promotion_option_coupon_group
 (
     id                  BIGINT NOT NULL AUTO_INCREMENT,
     promotion_option_id BIGINT NOT NULL,
-    coupon_id           BIGINT NOT NULL,
+    coupon_group_id           BIGINT NOT NULL,
     PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
## ✨ Issue
- #26 

## 🔑 Key changes
- [x] 프로모션 생성 API
- [x] 프로모션 상세 조회 API
- [x] 프로모션 리스트 조회 API
- [x] 프로모션 인수 테스트
- [x] 프로모션 서비스 테스트

## 👋 To reviewers
프로모션 저장시 흐름 : 
1. 프로모션 저장 
2. 프로모션 옵션 저장
3. 쿠폰그룹에 1에서 저장한 프로모션 주입
4. 프로모션_옵션_쿠폰그룹에 프로모션, 쿠폰그룹 저장

프로모션 상세 조회시 흐름:
1. 프로모션 조회
2. 프로모션 옵션 리스트 조회
3. 프로모션 옵션에 해당하는 쿠폰 그룹 조회
4. 상세페이지 반환

PR이 생각보다 너무 뚱뚱해져서....다음부터 다이어트 하겠습니다.
PR 읽다가 힘드시면 말씀해주세요 (__)
