### PR TITLE
[BE][feat] 쿠폰그룹 간단 목록 조회

### DIFF
--- a/be/promotion/src/docs/asciidoc/couponGroup.adoc
+++ b/be/promotion/src/docs/asciidoc/couponGroup.adoc
@@ -14,6 +14,25 @@ include::{snippets}/admin/coupon-groups/retrieve-coupon-groups/http-response.ado
 
 include::{snippets}/admin/coupon-groups/retrieve-coupon-groups/request-parameters.adoc[]
 
+==== Request Headers
+
+include::{snippets}/admin/coupon-groups/retrieve-simple-coupon-groups/request-headers.adoc[]
+
 ==== Response Fields
 
 include::{snippets}/admin/coupon-groups/retrieve-coupon-groups/response-fields.adoc[]
+
+=== 쿠폰그룹 간단 목록 조회
+
+.HTTP REQUEST
+include::{snippets}/admin/coupon-groups/retrieve-simple-coupon-groups/http-request.adoc[]
+.HTTP RESPONSE
+include::{snippets}/admin/coupon-groups/retrieve-simple-coupon-groups/http-response.adoc[]
+
+==== Request Headers
+
+include::{snippets}/admin/coupon-groups/retrieve-simple-coupon-groups/request-headers.adoc[]
+
+==== Response Fields
+
+include::{snippets}/admin/coupon-groups/retrieve-simple-coupon-groups/response-fields.adoc[]

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/application/CouponGroupService.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/application/CouponGroupService.java
@@ -14,6 +14,7 @@ import woowa.promotion.admin.coupon.infrastructure.CouponRepository;
 import woowa.promotion.admin.coupon_group.domain.CouponGroup;
 import woowa.promotion.admin.coupon_group.infrastructure.CouponGroupRepository;
 import woowa.promotion.admin.coupon_group.presentation.dto.CouponGroupCreateRequest;
+import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupSimpleResponse;
 import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupsResponse;
 import woowa.promotion.global.domain.page.CustomPage;
 
@@ -52,5 +53,9 @@ public class CouponGroupService {
                         pageable.getPageSize()
                 )
         );
+    }
+
+    public List<CouponGroupSimpleResponse> retrieveSimpleCouponGroups() {
+        return couponGroupRepository.findAllCouponGroupSimpleResponse();
     }
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/infrastructure/CouponGroupRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/infrastructure/CouponGroupRepository.java
@@ -1,6 +1,5 @@
 package woowa.promotion.admin.coupon_group.infrastructure;
 
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,12 +7,14 @@ import org.springframework.data.jpa.repository.Query;
 import woowa.promotion.admin.coupon_group.domain.CouponGroup;
 import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupSimpleResponse;
 
+import java.util.List;
+
 public interface CouponGroupRepository extends JpaRepository<CouponGroup, Long> {
 
     Page<CouponGroup> findAll(Pageable pageable);
 
     @Query("SELECT new woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupSimpleResponse(" +
-            "couponGroup.id,couponGroup.title" +
+            "couponGroup.id, couponGroup.title" +
             ") FROM CouponGroup couponGroup")
     List<CouponGroupSimpleResponse> findAllCouponGroupSimpleResponse();
 

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/infrastructure/CouponGroupRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/infrastructure/CouponGroupRepository.java
@@ -1,10 +1,12 @@
 package woowa.promotion.admin.coupon_group.infrastructure;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import woowa.promotion.admin.coupon_group.domain.CouponGroup;
+import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupSimpleResponse;
 
 public interface CouponGroupRepository extends JpaRepository<CouponGroup, Long> {
 
@@ -12,5 +14,10 @@ public interface CouponGroupRepository extends JpaRepository<CouponGroup, Long> 
             "FROM CouponGroup couponGroup " +
             "LEFT JOIN Coupon coupon ON couponGroup.id = coupon.couponGroup.id")
     Page<CouponGroup> findAll(Pageable pageable);
+
+    @Query("SELECT new woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupSimpleResponse(" +
+            "couponGroup.id,couponGroup.title" +
+            ") FROM CouponGroup couponGroup")
+    List<CouponGroupSimpleResponse> findAllCouponGroupSimpleResponse();
 
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/infrastructure/CouponGroupRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/infrastructure/CouponGroupRepository.java
@@ -10,9 +10,6 @@ import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupS
 
 public interface CouponGroupRepository extends JpaRepository<CouponGroup, Long> {
 
-    @Query(value = "SELECT DISTINCT couponGroup " +
-            "FROM CouponGroup couponGroup " +
-            "LEFT JOIN Coupon coupon ON couponGroup.id = coupon.couponGroup.id")
     Page<CouponGroup> findAll(Pageable pageable);
 
     @Query("SELECT new woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupSimpleResponse(" +

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/CouponGroupController.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/CouponGroupController.java
@@ -1,5 +1,6 @@
 package woowa.promotion.admin.coupon_group.presentation;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.admin.coupon_group.application.CouponGroupService;
 import woowa.promotion.admin.coupon_group.presentation.dto.CouponGroupCreateRequest;
+import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupSimpleResponse;
 import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupsResponse;
 import woowa.promotion.global.domain.page.CustomPage;
 import woowa.promotion.global.resolver.Authentication;
@@ -39,6 +41,11 @@ public class CouponGroupController {
             @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity.ok(couponGroupService.retrieveCouponGroups(pageable));
+    }
+
+    @GetMapping("/summary")
+    public ResponseEntity<List<CouponGroupSimpleResponse>> retrieveSimpleCouponGroups() {
+        return ResponseEntity.ok(couponGroupService.retrieveSimpleCouponGroups());
     }
 
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/dto/response/CouponGroupSimpleResponse.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/dto/response/CouponGroupSimpleResponse.java
@@ -1,0 +1,8 @@
+package woowa.promotion.admin.coupon_group.presentation.dto.response;
+
+public record CouponGroupSimpleResponse(
+
+        Long id,
+        String title
+) {
+}

--- a/be/promotion/src/test/java/woowa/promotion/admin/coupon_group/application/CouponGroupServiceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/coupon_group/application/CouponGroupServiceTest.java
@@ -15,6 +15,7 @@ import woowa.promotion.admin.coupon_group.domain.CouponGroup;
 import woowa.promotion.fixture.FixtureFactory;
 import woowa.promotion.util.ApplicationTest;
 
+@DisplayName("[비즈니스 로직 테스트] 쿠폰 그룹")
 class CouponGroupServiceTest extends ApplicationTest {
 
     @Autowired
@@ -24,14 +25,8 @@ class CouponGroupServiceTest extends ApplicationTest {
     @Test
     void retrieveCouponGroups() {
         // given
-        List<CouponGroup> couponGroups = new ArrayList<>();
-        IntStream.rangeClosed(1, 15)
-                .forEach(i -> couponGroups.add(
-                        supportRepository.save(FixtureFactory.createCouponGroup("cg - " + i)))
-                );
-        IntStream.rangeClosed(1, 45)
-                .forEach(i -> supportRepository.save(
-                        FixtureFactory.createCoupon("coupon - " + i, couponGroups.get(i % 15))));
+        int couponGroupCount = 15;
+        saveCouponGroupsAndCoupons(couponGroupCount);
 
         // when
         var response = couponGroupService.retrieveCouponGroups(PageRequest.of(1, 10, Direction.DESC, "id"));
@@ -45,5 +40,35 @@ class CouponGroupServiceTest extends ApplicationTest {
                 () -> assertThat(response.paging().totalElements()).isEqualTo(15),
                 () -> assertThat(response.paging().size()).isEqualTo(10)
         );
+    }
+
+    @DisplayName("쿠폰 그룹 간단 목록을 조회하면 id와 title만 조회된다.")
+    @Test
+    void retrieveSimpleCouponGroup() {
+        // given
+        int couponGroupCount = 15;
+        saveCouponGroupsAndCoupons(couponGroupCount);
+
+        // when
+        var response = couponGroupService.retrieveSimpleCouponGroups();
+
+        // then
+        assertAll(
+                () -> assertThat(response).hasSize(15),
+                () -> assertThat(response.get(0)).hasFieldOrProperty("id"),
+                () -> assertThat(response.get(0)).hasFieldOrProperty("title")
+        );
+    }
+
+    private void saveCouponGroupsAndCoupons(int couponGroupCount) {
+        List<CouponGroup> couponGroups = new ArrayList<>();
+
+        IntStream.rangeClosed(1, couponGroupCount)
+                .forEach(i -> couponGroups.add(
+                        supportRepository.save(FixtureFactory.createCouponGroup("cg - " + i)))
+                );
+        IntStream.rangeClosed(1, 45)
+                .forEach(i -> supportRepository.save(
+                        FixtureFactory.createCoupon("coupon - " + i, couponGroups.get(i % couponGroupCount))));
     }
 }

--- a/be/promotion/src/test/java/woowa/promotion/admin/documentation/CouponGroupDocumentationTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/documentation/CouponGroupDocumentationTest.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import woowa.promotion.admin.coupon_group.application.CouponGroupService;
+import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupSimpleResponse;
 import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupsResponse;
 import woowa.promotion.global.domain.page.CustomPage;
 import woowa.promotion.util.DocumentationTest;
@@ -110,6 +111,43 @@ public class CouponGroupDocumentationTest extends DocumentationTest {
                                 fieldWithPath("paging.totalPages").description("총 페이지 수"),
                                 fieldWithPath("paging.totalElements").description("총 요소 수"),
                                 fieldWithPath("paging.size").description("페이지 크기")
+                        )
+                ));
+    }
+
+    @DisplayName("쿠폰 그룹 간단 목록 조회")
+    @Test
+    void retrieveSimpleCouponGroups() throws Exception {
+        // given
+        given(couponGroupService.retrieveSimpleCouponGroups())
+                .willReturn(List.of(
+                        new CouponGroupSimpleResponse(1L, "쿠폰 그룹 제목 - 1"),
+                        new CouponGroupSimpleResponse(2L, "쿠폰 그룹 제목 - 2")
+                ));
+
+        // when
+        var response = mockMvc.perform(request(HttpMethod.GET, "/admin/coupon-groups/summary")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer abc.abc.abc"));
+
+        // then
+        var resultActions = response
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[*].id").exists())
+                .andExpect(jsonPath("$[*].title").exists());
+
+        // docs
+        resultActions
+                .andDo(document("admin/coupon-groups/retrieve-simple-coupon-groups",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("JWT 인증 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("[]").description("쿠폰 그룹 간단 목록"),
+                                fieldWithPath("[].id").description("쿠폰 그룹 ID"),
+                                fieldWithPath("[].title").description("쿠폰 그룹 제목")
                         )
                 ));
     }


### PR DESCRIPTION
## ✨ Issue
- #45 

## 🔑 Key changes
- 쿠폰그룹 간단 목록 조회 기능 구현
- 테스트코드 작성

### 수정 사항
기존에 CouponGroup을 페이징하여 조회하는 부분을 LEFT JOIN을 사용하여 가져오고 있었는데 잘못된 부분임을 깨달았습니다..
FETCH JOIN 하는 것이 아니라 일반 조인을 하기 때문에 연관된 Coupon 엔티티를 영속성 컨텍스트에 올리지 못하기 때문에 불필요한 조인 쿼리를 작성했습니다. 따라서 이를 제거하는 작업을 수행했습니다. (앞으로는 잘 알고 적용하겠습니담ㅠ)

## 👋 To reviewers
기능을 개발하면서 무한 스크롤 형식의 API가 더 낫겠다는 생각이 들었는데 어떻게 생각하시나요?
지금은 모든 목록들을 한 번에 보여주고 있습니당