### PR TITLE
[BE][feat] 쿠폰그룹 상세 조회

### DIFF
--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/application/CouponGroupService.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/application/CouponGroupService.java
@@ -14,9 +14,12 @@ import woowa.promotion.admin.coupon.infrastructure.CouponRepository;
 import woowa.promotion.admin.coupon_group.domain.CouponGroup;
 import woowa.promotion.admin.coupon_group.infrastructure.CouponGroupRepository;
 import woowa.promotion.admin.coupon_group.presentation.dto.CouponGroupCreateRequest;
+import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupDetailResponse;
 import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupSimpleResponse;
 import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupsResponse;
 import woowa.promotion.global.domain.page.CustomPage;
+import woowa.promotion.global.exception.ApiException;
+import woowa.promotion.global.exception.domain.CouponGroupException;
 
 @Service
 @RequiredArgsConstructor
@@ -57,5 +60,12 @@ public class CouponGroupService {
 
     public List<CouponGroupSimpleResponse> retrieveSimpleCouponGroups() {
         return couponGroupRepository.findAllCouponGroupSimpleResponse();
+    }
+
+    public CouponGroupDetailResponse retrieveDetailCouponGroup(Long couponGroupId) {
+        CouponGroup couponGroup = couponGroupRepository.findCouponGroupWithCouponsUsingFetchjoin(couponGroupId)
+                .orElseThrow(() -> new ApiException(CouponGroupException.NOT_FOUND));
+
+        return CouponGroupDetailResponse.of(couponGroup);
     }
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/application/CouponGroupService.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/application/CouponGroupService.java
@@ -66,6 +66,6 @@ public class CouponGroupService {
         CouponGroup couponGroup = couponGroupRepository.findCouponGroupWithCouponsUsingFetchjoin(couponGroupId)
                 .orElseThrow(() -> new ApiException(CouponGroupException.NOT_FOUND));
 
-        return CouponGroupDetailResponse.of(couponGroup);
+        return CouponGroupDetailResponse.from(couponGroup);
     }
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/infrastructure/CouponGroupRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/infrastructure/CouponGroupRepository.java
@@ -19,7 +19,7 @@ public interface CouponGroupRepository extends JpaRepository<CouponGroup, Long> 
             ") FROM CouponGroup couponGroup")
     List<CouponGroupSimpleResponse> findAllCouponGroupSimpleResponse();
 
-    @Query("SELECT cg FROM CouponGroup cg JOIN FETCH cg.coupons WHERE cg.id = :couponGroupId")
+    @Query("SELECT couponGroup FROM CouponGroup couponGroup JOIN FETCH couponGroup.coupons WHERE couponGroup.id = :couponGroupId")
     Optional<CouponGroup> findCouponGroupWithCouponsUsingFetchjoin(@Param("couponGroupId") Long counponGroupId);
 
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/infrastructure/CouponGroupRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/infrastructure/CouponGroupRepository.java
@@ -1,13 +1,14 @@
 package woowa.promotion.admin.coupon_group.infrastructure;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import woowa.promotion.admin.coupon_group.domain.CouponGroup;
 import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupSimpleResponse;
-
-import java.util.List;
 
 public interface CouponGroupRepository extends JpaRepository<CouponGroup, Long> {
 
@@ -17,5 +18,8 @@ public interface CouponGroupRepository extends JpaRepository<CouponGroup, Long> 
             "couponGroup.id, couponGroup.title" +
             ") FROM CouponGroup couponGroup")
     List<CouponGroupSimpleResponse> findAllCouponGroupSimpleResponse();
+
+    @Query("SELECT cg FROM CouponGroup cg JOIN FETCH cg.coupons WHERE cg.id = :couponGroupId")
+    Optional<CouponGroup> findCouponGroupWithCouponsUsingFetchjoin(@Param("couponGroupId") Long counponGroupId);
 
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/CouponGroupController.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/CouponGroupController.java
@@ -8,6 +8,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.admin.coupon_group.application.CouponGroupService;
 import woowa.promotion.admin.coupon_group.presentation.dto.CouponGroupCreateRequest;
+import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupDetailResponse;
 import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupSimpleResponse;
 import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupsResponse;
 import woowa.promotion.global.domain.page.CustomPage;
@@ -48,4 +50,10 @@ public class CouponGroupController {
         return ResponseEntity.ok(couponGroupService.retrieveSimpleCouponGroups());
     }
 
+    @GetMapping("/{couponGroupId}")
+    public ResponseEntity<CouponGroupDetailResponse> retriveDetailCouponCroup(
+            @PathVariable Long couponGroupId
+    ) {
+        return ResponseEntity.ok(couponGroupService.retrieveDetailCouponGroup(couponGroupId));
+    }
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/dto/response/CouponGroupDetailResponse.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/dto/response/CouponGroupDetailResponse.java
@@ -18,18 +18,18 @@ public record CouponGroupDetailResponse(
             Integer discount,
             Integer initialQuantity
     ) {
-        public static CouponGroupCouponResponse of(Coupon coupon) {
+        public static CouponGroupCouponResponse from(Coupon coupon) {
             return new CouponGroupCouponResponse(coupon.getTitle(), coupon.getType().name(), coupon.getDiscount(),
                     coupon.getInitialQuantity());
         }
     }
 
-    public static CouponGroupDetailResponse of(CouponGroup couponGroup) {
+    public static CouponGroupDetailResponse from(CouponGroup couponGroup) {
         return new CouponGroupDetailResponse(
                 couponGroup.getTitle(),
                 couponGroup.getStartedAt(),
                 couponGroup.getFinishedAt(),
-                couponGroup.getCoupons().stream().map(CouponGroupCouponResponse::of).toList()
+                couponGroup.getCoupons().stream().map(CouponGroupCouponResponse::from).toList()
         );
     }
 }

--- a/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/dto/response/CouponGroupDetailResponse.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/coupon_group/presentation/dto/response/CouponGroupDetailResponse.java
@@ -1,0 +1,35 @@
+package woowa.promotion.admin.coupon_group.presentation.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+import woowa.promotion.admin.coupon.domain.Coupon;
+import woowa.promotion.admin.coupon_group.domain.CouponGroup;
+
+public record CouponGroupDetailResponse(
+        String title,
+        Instant startedAt,
+        Instant finishedAt,
+        List<CouponGroupCouponResponse> coupons
+) {
+
+    public record CouponGroupCouponResponse(
+            String title,
+            String type,
+            Integer discount,
+            Integer initialQuantity
+    ) {
+        public static CouponGroupCouponResponse of(Coupon coupon) {
+            return new CouponGroupCouponResponse(coupon.getTitle(), coupon.getType().name(), coupon.getDiscount(),
+                    coupon.getInitialQuantity());
+        }
+    }
+
+    public static CouponGroupDetailResponse of(CouponGroup couponGroup) {
+        return new CouponGroupDetailResponse(
+                couponGroup.getTitle(),
+                couponGroup.getStartedAt(),
+                couponGroup.getFinishedAt(),
+                couponGroup.getCoupons().stream().map(CouponGroupCouponResponse::of).toList()
+        );
+    }
+}

--- a/be/promotion/src/test/java/woowa/promotion/acceptance/CouponGroupAcceptanceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/acceptance/CouponGroupAcceptanceTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.admin.coupon_group.domain.CouponGroup;
+import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupDetailResponse.CouponGroupCouponResponse;
 import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupsResponse;
 import woowa.promotion.fixture.FixtureFactory;
 import woowa.promotion.global.domain.page.CustomPage;
@@ -101,6 +102,38 @@ public class CouponGroupAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.jsonPath().getObject("[0]", CouponGroup.class))
                         .hasFieldOrProperty("id")
                         .hasFieldOrProperty("title")
+        );
+    }
+
+    @DisplayName("쿠폰 그룹 상세 목록을 조회한다.")
+    @Test
+    void retrieveDetailCouponGroup() {
+        // given
+        Admin admin = supportRepository.save(FixtureFactory.createAdmin(passwordEncoder.encrypt("1234")));
+        saveCouponGroupsAndCoupons();
+        String accessToken = jwtProvider.createAccessToken(Map.of("adminId", admin.getId()));
+
+        // when
+        var response = RestAssured
+                .given().log().all()
+                .auth().oauth2(accessToken)
+                .get("/admin/coupon-groups/1")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getString("title")).isNotBlank(),
+                () -> assertThat(response.jsonPath().getString("startedAt")).isNotBlank(),
+                () -> assertThat(response.jsonPath().getString("finishedAt")).isNotBlank(),
+                () -> assertThat(response.jsonPath().getList("coupons", CouponGroupCouponResponse.class)).hasSize(3),
+                () -> assertThat(response.jsonPath().getObject("coupons[0]", CouponGroupCouponResponse.class))
+                        .hasFieldOrProperty("title")
+                        .hasFieldOrProperty("type")
+                        .hasFieldOrProperty("discount")
+                        .hasFieldOrProperty("initialQuantity")
+
         );
     }
 

--- a/be/promotion/src/test/java/woowa/promotion/acceptance/CouponGroupAcceptanceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/acceptance/CouponGroupAcceptanceTest.java
@@ -133,7 +133,6 @@ public class CouponGroupAcceptanceTest extends AcceptanceTest {
                         .hasFieldOrProperty("type")
                         .hasFieldOrProperty("discount")
                         .hasFieldOrProperty("initialQuantity")
-
         );
     }
 

--- a/be/promotion/src/test/java/woowa/promotion/admin/coupon_group/application/CouponGroupServiceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/coupon_group/application/CouponGroupServiceTest.java
@@ -4,14 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.BiPredicate;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort.Direction;
+import woowa.promotion.admin.coupon.domain.Coupon;
 import woowa.promotion.admin.coupon_group.domain.CouponGroup;
+import woowa.promotion.admin.coupon_group.presentation.dto.response.CouponGroupDetailResponse.CouponGroupCouponResponse;
 import woowa.promotion.fixture.FixtureFactory;
 import woowa.promotion.util.ApplicationTest;
 
@@ -58,6 +63,35 @@ class CouponGroupServiceTest extends ApplicationTest {
                 () -> assertThat(response.get(0)).hasFieldOrProperty("id"),
                 () -> assertThat(response.get(0)).hasFieldOrProperty("title")
         );
+    }
+
+    @DisplayName("쿠폰 그룹 상세페이지를 조회한다.")
+    @Test
+    void retrieveDetailCouponGroup() {
+        // given
+        int couponGroupCount = 1;
+        saveCouponGroupsAndCoupons(couponGroupCount);
+        CouponGroup couponGroup = supportRepository.findAll(CouponGroup.class).get(0);
+        List<Coupon> coupons = supportRepository.findAll(Coupon.class).stream()
+                .sorted(Comparator.comparing(Coupon::getTitle)).toList();
+
+        // when
+        var response = couponGroupService.retrieveDetailCouponGroup(couponGroup.getId());
+
+        // then
+        BiPredicate<CouponGroupCouponResponse, Coupon> myCompare = (d1, d2) -> Objects.equals(d1.type(),
+                d2.getType().name());
+
+        assertAll(
+                () -> assertThat(couponGroup.getTitle()).isEqualTo(response.title()),
+                () -> assertThat(couponGroup.getStartedAt()).isEqualTo(response.startedAt()),
+                () -> assertThat(couponGroup.getFinishedAt()).isEqualTo(response.finishedAt())
+        );
+        assertThat(response.coupons().stream().sorted(Comparator.comparing(CouponGroupCouponResponse::title)).toList())
+                .usingRecursiveComparison()
+                .withEqualsForFields(myCompare, "type")
+                .ignoringFields("type")
+                .isEqualTo(coupons);
     }
 
     private void saveCouponGroupsAndCoupons(int couponGroupCount) {

--- a/be/promotion/src/test/java/woowa/promotion/admin/coupon_group/application/CouponGroupServiceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/admin/coupon_group/application/CouponGroupServiceTest.java
@@ -85,13 +85,15 @@ class CouponGroupServiceTest extends ApplicationTest {
         assertAll(
                 () -> assertThat(couponGroup.getTitle()).isEqualTo(response.title()),
                 () -> assertThat(couponGroup.getStartedAt()).isEqualTo(response.startedAt()),
-                () -> assertThat(couponGroup.getFinishedAt()).isEqualTo(response.finishedAt())
+                () -> assertThat(couponGroup.getFinishedAt()).isEqualTo(response.finishedAt()),
+                () -> assertThat(
+                        response.coupons().stream().sorted(Comparator.comparing(CouponGroupCouponResponse::title))
+                                .toList())
+                        .usingRecursiveComparison()
+                        .withEqualsForFields(myCompare, "type")
+                        .ignoringFields("type")
+                        .isEqualTo(coupons)
         );
-        assertThat(response.coupons().stream().sorted(Comparator.comparing(CouponGroupCouponResponse::title)).toList())
-                .usingRecursiveComparison()
-                .withEqualsForFields(myCompare, "type")
-                .ignoringFields("type")
-                .isEqualTo(coupons);
     }
 
     private void saveCouponGroupsAndCoupons(int couponGroupCount) {


### PR DESCRIPTION
## ✨ Issue
- #52 

## 🔑 Key changes
- [x] 쿠폰 그룹 상세조회 API 구현
- [x] 쿠폰 그룹 상세조회 API RestDocs, Test 구현

## 👋 To reviewers
쿠폰 그룹에 해당하는 쿠폰까지 가져와야하기 때문에 join fetch를 사용하였습니다.