### PR TITLE
[BE][feat] 회원 프로모션 목록 조회

### DIFF
--- a/be/promotion/src/docs/asciidoc/appPromotion.adoc
+++ b/be/promotion/src/docs/asciidoc/appPromotion.adoc
@@ -1,0 +1,19 @@
+[[AppPromotion]]
+:toc: left
+:toclevels: 4
+== 앱 프로모션
+
+=== 앱 프로모션 목록 조회
+
+.HTTP Request
+include::{snippets}/app-promotion/retrieve/http-request.adoc[]
+.HTTP Response
+include::{snippets}/app-promotion/retrieve/http-response.adoc[]
+
+==== Request Headers
+
+include::{snippets}/app-promotion/retrieve/request-headers.adoc[]
+
+==== Response Fields
+
+include::{snippets}/app-promotion/retrieve/response-fields.adoc[]

--- a/be/promotion/src/docs/asciidoc/index.adoc
+++ b/be/promotion/src/docs/asciidoc/index.adoc
@@ -12,5 +12,11 @@
 
 프로모션 & 쿠폰 시스템 API
 
+=== 관리자
+
 include::admin.adoc[]
 include::couponGroup.adoc[]
+
+=== 사용자
+
+include::appPromotion.adoc[]

--- a/be/promotion/src/main/java/woowa/promotion/admin/promotion/infrastructure/PromotionRepository.java
+++ b/be/promotion/src/main/java/woowa/promotion/admin/promotion/infrastructure/PromotionRepository.java
@@ -1,7 +1,17 @@
 package woowa.promotion.admin.promotion.infrastructure;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import woowa.promotion.admin.promotion.domain.Promotion;
+import woowa.promotion.app.promotion.presentation.dto.AppPromotionResponse;
+
+import java.util.List;
 
 public interface PromotionRepository extends JpaRepository<Promotion, Long> {
+
+    @Query("SELECT new woowa.promotion.app.promotion.presentation.dto.AppPromotionResponse(" +
+            "promotion.id, promotion.bannerUrl, promotion.promotionPageUrl" +
+            ") FROM Promotion promotion WHERE promotion.isDisplay = true")
+    List<AppPromotionResponse> findAllByIsDisplayTrue();
+
 }

--- a/be/promotion/src/main/java/woowa/promotion/app/promotion/application/AppPromotionService.java
+++ b/be/promotion/src/main/java/woowa/promotion/app/promotion/application/AppPromotionService.java
@@ -1,0 +1,22 @@
+package woowa.promotion.app.promotion.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import woowa.promotion.admin.promotion.infrastructure.PromotionRepository;
+import woowa.promotion.app.promotion.presentation.dto.AppPromotionResponse;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class AppPromotionService {
+
+    private final PromotionRepository promotionRepository;
+
+    public List<AppPromotionResponse> retrievePromotions() {
+        return promotionRepository.findAllByIsDisplayTrue();
+    }
+
+}

--- a/be/promotion/src/main/java/woowa/promotion/app/promotion/presentation/AppPromotionController.java
+++ b/be/promotion/src/main/java/woowa/promotion/app/promotion/presentation/AppPromotionController.java
@@ -1,0 +1,25 @@
+package woowa.promotion.app.promotion.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import woowa.promotion.app.promotion.application.AppPromotionService;
+import woowa.promotion.app.promotion.presentation.dto.AppPromotionResponse;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/app/promotions")
+@RestController
+public class AppPromotionController {
+
+    private final AppPromotionService appPromotionService;
+
+    @GetMapping
+    public ResponseEntity<List<AppPromotionResponse>> retrievePromotions() {
+        return ResponseEntity.ok(appPromotionService.retrievePromotions());
+    }
+
+}

--- a/be/promotion/src/main/java/woowa/promotion/app/promotion/presentation/dto/AppPromotionResponse.java
+++ b/be/promotion/src/main/java/woowa/promotion/app/promotion/presentation/dto/AppPromotionResponse.java
@@ -1,0 +1,20 @@
+package woowa.promotion.app.promotion.presentation.dto;
+
+import woowa.promotion.admin.promotion.domain.Promotion;
+
+public record AppPromotionResponse(
+
+        Long id,
+        String bannerUrl,
+        String promotionPageUrl
+) {
+
+    public static AppPromotionResponse from(Promotion promotion) {
+        return new AppPromotionResponse(
+                promotion.getId(),
+                promotion.getBannerUrl(),
+                promotion.getPromotionPageUrl()
+        );
+    }
+
+}

--- a/be/promotion/src/test/java/woowa/promotion/acceptance/AppPromotionAcceptanceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/acceptance/AppPromotionAcceptanceTest.java
@@ -1,0 +1,53 @@
+package woowa.promotion.acceptance;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import woowa.promotion.app.promotion.presentation.dto.AppPromotionResponse;
+import woowa.promotion.fixture.FixtureFactory;
+import woowa.promotion.fixture.PromotionFixture;
+import woowa.promotion.fixture.UserFixture;
+import woowa.promotion.util.AcceptanceTest;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("[인수 테스트] 회원 프로모션")
+public class AppPromotionAcceptanceTest extends AcceptanceTest {
+
+    @DisplayName("회원이 프로모션 조회시 노출여부가 true인 프로모션만 조회된다.")
+    @Test
+    void retrievePromotions() {
+        // given
+        supportRepository.save(FixtureFactory.createMember(UserFixture.유저_June, passwordEncoder.encrypt("1234")));
+
+        supportRepository.save(FixtureFactory.createPromotion(PromotionFixture.A_프로모션));
+        supportRepository.save(FixtureFactory.createPromotion(PromotionFixture.B_프로모션));
+        supportRepository.save(FixtureFactory.createPromotion(PromotionFixture.C_프로모션));
+
+        var request = RestAssured
+                .given().log().all()
+                .auth().oauth2(jwtProvider.createAccessToken(Map.of("memberId", 1L)));
+
+        // when
+        var response = request
+                .when()
+                .get("/app/promotions")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getList(".", AppPromotionResponse.class)).hasSize(2),
+                () -> assertThat(response.jsonPath().getObject("[0]", AppPromotionResponse.class))
+                        .hasFieldOrProperty("id")
+                        .hasFieldOrProperty("bannerUrl")
+                        .hasFieldOrProperty("promotionPageUrl")
+        );
+    }
+
+}

--- a/be/promotion/src/test/java/woowa/promotion/app/documentation/PromotionDocumentationTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/app/documentation/PromotionDocumentationTest.java
@@ -1,0 +1,72 @@
+package woowa.promotion.app.documentation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import woowa.promotion.app.promotion.application.AppPromotionService;
+import woowa.promotion.app.promotion.presentation.dto.AppPromotionResponse;
+import woowa.promotion.util.DocumentationTest;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("[RESTDocs] 회원 프로모션 API")
+public class PromotionDocumentationTest extends DocumentationTest {
+
+    @Autowired
+    private AppPromotionService appPromotionService;
+
+    @DisplayName("프로모션 목록 조회")
+    @Test
+    void retrievePromotions() throws Exception {
+        // given
+        given(appPromotionService.retrievePromotions()).willReturn(createAppPromotionResponse());
+
+        // when
+        var response = mockMvc
+                .perform(request(HttpMethod.GET, "/app/promotions")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer abc.abc.abc"));
+
+        // then
+        var resultActions = response
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[*].id").exists())
+                .andExpect(jsonPath("$[*].bannerUrl").exists())
+                .andExpect(jsonPath("$[*].promotionPageUrl").exists());
+
+        // docs
+        resultActions
+                .andDo(document("app-promotion/retrieve",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("JWT 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("[].id").description("프로모션 ID"),
+                                fieldWithPath("[].bannerUrl").description("프로모션 배너 URL"),
+                                fieldWithPath("[].promotionPageUrl").description("프로모션 페이지 URL")
+                        )
+                ));
+    }
+
+    private List<AppPromotionResponse> createAppPromotionResponse() {
+        return List.of(
+                new AppPromotionResponse(1L, "bannerUrl", "promotionPageUrl"),
+                new AppPromotionResponse(2L, "bannerUrl2", "promotionPageUrl2")
+        );
+    }
+
+}

--- a/be/promotion/src/test/java/woowa/promotion/app/promotion/application/AppPromotionServiceTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/app/promotion/application/AppPromotionServiceTest.java
@@ -1,0 +1,40 @@
+package woowa.promotion.app.promotion.application;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import woowa.promotion.fixture.FixtureFactory;
+import woowa.promotion.fixture.PromotionFixture;
+import woowa.promotion.util.ApplicationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("[비즈니스 로직 테스트] 회원 프로모션")
+class AppPromotionServiceTest extends ApplicationTest {
+
+    @Autowired
+    private AppPromotionService appPromotionService;
+
+    @DisplayName("회원이 프로모션 조회시 노출여부가 true인 프로모션만 조회된다.")
+    @Test
+    void retrieveIsDisplayEqualsTruePromotions() {
+        // given
+        supportRepository.save(FixtureFactory.createPromotion(PromotionFixture.A_프로모션));
+        supportRepository.save(FixtureFactory.createPromotion(PromotionFixture.B_프로모션));
+        supportRepository.save(FixtureFactory.createPromotion(PromotionFixture.C_프로모션));    // is_display = false
+
+        // when
+        var response = appPromotionService.retrievePromotions();
+
+        // then
+        assertAll(
+                () -> assertThat(response).hasSize(2),
+                () -> assertThat(response.get(0))
+                        .hasFieldOrProperty("id")
+                        .hasFieldOrProperty("bannerUrl")
+                        .hasFieldOrProperty("promotionPageUrl")
+        );
+    }
+
+}

--- a/be/promotion/src/test/java/woowa/promotion/fixture/PromotionFixture.java
+++ b/be/promotion/src/test/java/woowa/promotion/fixture/PromotionFixture.java
@@ -1,7 +1,8 @@
 package woowa.promotion.fixture;
 
-import java.time.Instant;
 import woowa.promotion.admin.promotion.domain.ProgressStatus;
+
+import java.time.Instant;
 
 public enum PromotionFixture {
 
@@ -9,7 +10,10 @@ public enum PromotionFixture {
             "www.promotionUrl.com", true, ProgressStatus.ON_GOING.name()),
     B_프로모션("나만 10만원", "먹기 싫은"
             + " 음식을 고르세요", "www.bannerUrl.com", Instant.now(), Instant.now(),
-            "www.promotionUrl.com", true, ProgressStatus.ON_GOING.name());
+            "www.promotionUrl.com", true, ProgressStatus.ON_GOING.name()),
+    C_프로모션("추석 이벤트", "즐거운 한가위"
+            + " 음식을 고르세요", "www.bannerUrl.com", Instant.now(), Instant.now().plusSeconds(3600 * 24 * 7),
+            "www.promotionUrl.com", false, ProgressStatus.ON_GOING.name());
 
     private final String title;
     private final String content;

--- a/be/promotion/src/test/java/woowa/promotion/util/DocumentationTest.java
+++ b/be/promotion/src/test/java/woowa/promotion/util/DocumentationTest.java
@@ -1,8 +1,5 @@
 package woowa.promotion.util;
 
-import static org.mockito.BDDMockito.any;
-import static org.mockito.BDDMockito.given;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,16 +12,23 @@ import woowa.promotion.admin.admin.domain.Admin;
 import woowa.promotion.admin.admin.presentation.AuthController;
 import woowa.promotion.admin.coupon_group.application.CouponGroupService;
 import woowa.promotion.admin.coupon_group.presentation.CouponGroupController;
+import woowa.promotion.app.promotion.application.AppPromotionService;
+import woowa.promotion.app.promotion.presentation.AppPromotionController;
 import woowa.promotion.global.interceptor.AuthInterceptor;
 import woowa.promotion.global.resolver.AuthArgumentResolver;
 
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+
 @MockBean({
         AdminService.class,
-        CouponGroupService.class
+        CouponGroupService.class,
+        AppPromotionService.class
 })
 @WebMvcTest({
         AuthController.class,
-        CouponGroupController.class
+        CouponGroupController.class,
+        AppPromotionController.class
 })
 @AutoConfigureRestDocs
 public abstract class DocumentationTest {


### PR DESCRIPTION
## ✨ Issue
- #51 

## 🔑 Key changes
- 회원 프로모션 목록 조회 기능구현
  - 회원에게 노출되는 프로모션은 페이징할 정도로 많지 않을 것이라 예상했기 때문에 따로 페이징 처리는 하지 않았습니다.
  - `promotion` 테이블의 `is_display` 컬럼 값이 true인 것만 반환하도록 했습니다.
- 테스트코드 작성

## 👋 To reviewers
우선 레포지토리에서 DTO projection으로 반환하도록 했습니다~ 반환 값이 변경되도 해당 dto record class에서 필드를 추가하는 방법으로 대응할 수 있을 것이라 예상했습니답~!
