### PR TITLE
[FE][feat] 상태 배지 컴포넌트 구현

### DIFF
--- a/fe/src/components/common/statusBadge/StateBadge.styles.ts
+++ b/fe/src/components/common/statusBadge/StateBadge.styles.ts
@@ -1,0 +1,26 @@
+import { css } from "@emotion/react";
+import { colors } from "@styles/base/Color";
+import { fonts } from "@styles/base/Font";
+import { radius } from "@styles/base/Object";
+
+const StateBadgeTypes = {
+    PROCEEDING: {title: "진행중", color: colors.GREEN},
+    EXPECTED: {title: "예정", color: colors.BLUE},
+    TERMINATED: {title: "종료", color: colors.GRAY_900},
+}
+
+const stateBadgeStyle = (type: keyof typeof StateBadgeTypes) => css`
+    width: 54px;
+    height: 22px;
+    flex-hrink: 0;
+    border-radius: ${radius.medium};
+    background: ${StateBadgeTypes[type].color};
+
+    text-align: center;
+    color: ${colors.WHITE};
+    font: ${fonts.regular16};
+    line-height: 22px;
+    letter-spacing: 0.12px;
+`;
+
+export {StateBadgeTypes, stateBadgeStyle};

--- a/fe/src/components/common/statusBadge/StateBadge.tsx
+++ b/fe/src/components/common/statusBadge/StateBadge.tsx
@@ -1,0 +1,16 @@
+/** @jsxImportSource @emotion/react */
+import { StateBadgeTypes, stateBadgeStyle } from "./StateBadge.styles";
+
+type Props = {
+    type: keyof typeof StateBadgeTypes,
+}
+
+export default function StateBadge(props: Props) {
+
+    return (
+        <div
+            css={stateBadgeStyle(props.type)}>
+            {StateBadgeTypes[props.type].title}
+        </div>
+    );
+}


### PR DESCRIPTION
## ✨ Issue
- #43 

## 🔑 Key changes
- [x] 상태 배지 컴포넌트 구현

## 👋 To reviewers
- 진행중, 예정, 종료 세가지 상태의 배지를 보여줍니다.
<img width="52" alt="image" src="https://github.com/woowa-coupons/woowa-coupons/assets/86359180/7afc1dcb-bad3-4585-9d41-3fc1a0bcd196">

### 아래처럼 사용합니다.
```html
    <StateBadge type={"PROCEEDING"}></StateBadge>
    <StateBadge type={"EXPECTED"}></StateBadge>
    <StateBadge type={"TERMINATED"}></StateBadge>
```

### 미구현
- 아이콘 추가 안했어요.
